### PR TITLE
Update horde-translation

### DIFF
--- a/bin/horde-translation
+++ b/bin/horde-translation
@@ -99,7 +99,7 @@ class Horde_Translation_Script
      *
      * @param string $message  The text to write on the screen.
      */
-    public function writeln($message)
+    public function writeln($message = '')
     {
         $this->cli->writeln($message);
     }


### PR DESCRIPTION
Fix fatal errors on using writeln() without argument for new lines.
This broke on recent php due to missing required parameter.