### PR TITLE
Conditionally make rampage.php delay auth depending on version of Core

### DIFF
--- a/rampage.php
+++ b/rampage.php
@@ -49,10 +49,16 @@ add filtered requests/blue_filter port to Horde?
  * @license  http://www.horde.org/licenses/lgpl LGPL-2
  * @package  Horde
  */
-
 require_once __DIR__ . '/lib/Application.php';
-Horde_Registry::appInit('horde');
-
+/** 
+ * postpone authentication for RequestMapper if Core is new enough
+ * otherwise don't let any unauthenticated user slip through
+ */
+if (class_exists(Horde_Core_Controller_NotAuthorized)) {
+    Horde_Registry::appInit('horde', array('authentication' => 'none'));
+} else {
+    Horde_Registry::appInit('horde');
+}
 $request = $injector->getInstance('Horde_Controller_Request');
 
 $runner = $injector->getInstance('Horde_Controller_Runner');


### PR DESCRIPTION
Allow delaying controller framework auth to RequestMapper stage depending on presence of a new class (prevents accidental no-auth situation)

- won't hurt by itself
- related to https://github.com/horde/Core/pull/5/  Horde_Core_Controller upgrade
- Should be backward compatible