### PR TITLE
Update activesync.php : remove unused variable which throws php error

### DIFF
--- a/admin/activesync.php
+++ b/admin/activesync.php
@@ -32,7 +32,6 @@ if ($actionID = Horde_Util::getPost('actionID')) {
 
     $device_desc = explode(':', $deviceID);
     $deviceID = $device_desc[0];
-    $user = $device_desc[1];
 
     switch ($actionID) {
     case 'wipe':


### PR DESCRIPTION
if deviceID is empty, the exploded arrary doesn't contain [1] whcih throws an PHP error.

as the variable $user is anyway not used, remove it.