### PR TITLE
Fix: Typo in horde-translation

### DIFF
--- a/bin/horde-translation
+++ b/bin/horde-translation
@@ -1275,7 +1275,7 @@ class Horde_Translation_Script
                     rename($pofile . '.tmp', $pofile);
                     $this->writeln($this->cli->green('done'));
                 } else {
-                    unlink($pofile . '.tmp', $pofile);
+                    unlink($pofile . '.tmp');
                     $this->writeln($this->cli->red('failed'));
                 }
                 $this->writeln();


### PR DESCRIPTION
Correcting a typo.
Fatal Error:                                                                                    
  unlink(): Argument #2 ($context) must be of type resource or null, string given                 
  In /var/www/horde-git/horde/base/bin/horde-translation on line 1278