### PR TITLE
Allow to set custom error message returned by OTPAuth module

### DIFF
--- a/login.php
+++ b/login.php
@@ -164,18 +164,20 @@ if ($logout_reason) {
     if ($loginHandler->secondFactorSupported) {
         try {
             $authSecondFactor = (string) Horde_Util::getPost('horde_secondfactor');
-            $passSecondFactor = $registry->call('secondfactor/checkInput', [
+            $errorSecondFactor = $registry->call('secondfactor/blockLogin', [
                 $authUser,
                 $authSecondFactor,
             ]);
         } catch (Horde_Exception $e) {
+            $errorSecondFactor = Horde_Auth::REASON_BADLOGIN;
+        }
+
+        if ($errorSecondFactor) {
             $passSecondFactor = false;
+            $auth->setError($errorSecondFactor);
         }
     }
-    // Security demands we do not allow the user to test the factors individually. Twofactor failure must look like a bad password.
-    if (!$passSecondFactor) {
-        $auth->setError(Horde_Auth::REASON_BADLOGIN);
-    }
+
     if ($passSecondFactor && $auth->authenticate($authUser, $auth_params)) {
         Horde::log(
             sprintf(


### PR DESCRIPTION
While I understand the possible security concerns, I believe it still makes sense to report that OTP is invalid (or missing).

This, otherwise, would make it very difficult for end users to understand why their login did not work.

And, it does not help with brute force attacks in any way due to the nature of OTP.

If this change is not acceptable, we should at least consider making it a configurable non-default option for those who would want it.
