### PR TITLE
Fix: TOTP Login Error Message and reload handling / split off #21

### DIFF
--- a/login.php
+++ b/login.php
@@ -160,25 +160,28 @@ if ($logout_reason) {
     // TODO: Factor out into login handler class
     // First check if we need to validate the second factor.
     $authUser = Horde_Util::getPost('horde_user') ?? '';
-    $passSecondFactor = true;
+    $errorSecondFactor = false;
     if ($loginHandler->secondFactorSupported) {
+        $message = null;
         try {
             $authSecondFactor = (string) Horde_Util::getPost('horde_secondfactor');
-            $errorSecondFactor = $registry->call('secondfactor/blockLogin', [
+            $message = $registry->call('secondfactor/blockLogin', [
                 $authUser,
                 $authSecondFactor,
             ]);
+            if ($message) {
+                $errorSecondFactor = Horde_Auth::REASON_MESSAGE;
+            }
         } catch (Horde_Exception $e) {
             $errorSecondFactor = Horde_Auth::REASON_BADLOGIN;
         }
 
         if ($errorSecondFactor) {
-            $passSecondFactor = false;
-            $auth->setError($errorSecondFactor);
+            $auth->setError($errorSecondFactor, $message);
         }
     }
 
-    if ($passSecondFactor && $auth->authenticate($authUser, $auth_params)) {
+    if (!$errorSecondFactor && $auth->authenticate($authUser, $auth_params)) {
         Horde::log(
             sprintf(
                 'Login success for %s to %s (%s)%s',

--- a/src/Login.php
+++ b/src/Login.php
@@ -40,7 +40,8 @@ class Login
             $loginparams['horde_secondfactor'] = [
                 'label' => _("Second Factor"),
                 'type' => 'password',
-                'value' => $this->vars->horde_secondfactor,
+                // 'value' => $this->vars->horde_secondfactor,
+                'extra' => [ 'autocomplete' => 'off' ],
             ];
         }
         return $loginparams;


### PR DESCRIPTION
This is split off PR #21 to separate the TOTP related fixes from the login refactor.
- Complete previous redesign from checkInput: (true valid or false invalid) to blockLogin: string (falsy or message)
- Don't offer to store OTP from vars to form on reload / forward