### PR TITLE
Refactor second factor validation to rely on Login::secondFactorApi()

### DIFF
--- a/login.php
+++ b/login.php
@@ -168,13 +168,13 @@ if ($logout_reason) {
 
     // TODO: Factor out into login handler class
     // First check if we need to validate the second factor.
-    $authUser = Horde_Util::getPost('horde_user') ?? '';
-    $errorSecondFactor = false;
-    if ($loginHandler->secondFactorMode > 0) {
+    $authUser = (string) Horde_Util::getPost('horde_user');
+    $errorSecondFactor = Horde_Auth::REASON_SUCCESS;
+    if ($loginHandler->secondFactorSupported()) {
         $message = null;
         try {
             $authSecondFactor = (string) Horde_Util::getPost('horde_secondfactor');
-            $message = $registry->call('secondfactor/blockLogin', [
+            $message = $loginHandler->secondFactorApi('blockLogin', 'Second factor API error', [
                 $authUser,
                 $authSecondFactor,
             ]);
@@ -185,12 +185,12 @@ if ($logout_reason) {
             $errorSecondFactor = Horde_Auth::REASON_BADLOGIN;
         }
 
-        if ($errorSecondFactor) {
+        if ($errorSecondFactor !== Horde_Auth::REASON_SUCCESS) {
             $auth->setError($errorSecondFactor, $message);
         }
     }
 
-    if (!$errorSecondFactor && $auth->authenticate($authUser, $auth_params)) {
+    if ($errorSecondFactor === Horde_Auth::REASON_SUCCESS && $auth->authenticate($authUser, $auth_params)) {
         Horde::log(
             sprintf(
                 'Login success for %s to %s (%s)%s',

--- a/src/Auth/ResponsiveLoginController.php
+++ b/src/Auth/ResponsiveLoginController.php
@@ -421,9 +421,9 @@ class ResponsiveLoginController implements RequestHandlerInterface
 
         // Validate second factor if enabled
         $loginHandler = $injector?->getInstance(Login::class);
-        if ($loginHandler && $loginHandler->secondFactorSupported) {
+        if ($loginHandler && $loginHandler->secondFactorSupported()) {
             try {
-                $message = $registry->call('secondfactor/blockLogin', [
+                $message = $loginHandler->secondFactorAPI('blockLogin', 'Second factor API error', [
                     $username,
                     $secondFactor,
                 ]);

--- a/src/Login.php
+++ b/src/Login.php
@@ -10,26 +10,38 @@ use Horde_Variables;
  */
 class Login
 {
+    public const SECOND_FACTOR_DISABLED = 0;
+    public const SECOND_FACTOR_SHOWCODE = 1;
+    public const SECOND_FACTOR_HIDECODE = 2;
+
     public readonly int $secondFactorMode;
-    public function __construct(private Horde_Registry $registry, private Horde_Variables $vars)
-    {
+
+    public function __construct(
+        private Horde_Registry $registry,
+        private Horde_Variables $vars
+    ) {
         if ($this->secondFactorApi('isEnabled', false)) {
             if ($this->secondFactorApi('showCode', true)) {
-                $mode = 1;
+                $mode = self::SECOND_FACTOR_SHOWCODE;
             } else {
-                $mode = 2;
+                $mode = self::SECOND_FACTOR_HIDECODE;
             }
         } else {
-            $mode = 0;
+            $mode = self::SECOND_FACTOR_DISABLED;
         }
         $this->secondFactorMode = $mode;
     }
 
-    private function secondFactorApi(string $method, $default)
+    public function secondFactorSupported(): bool
+    {
+        return $this->secondFactorMode !== self::SECOND_FACTOR_DISABLED;
+    }
+
+    public function secondFactorApi(string $method, mixed $default, array $params = []): mixed
     {
         $method = 'secondfactor/' . $method;
         if ($this->registry->hasMethod($method)) {
-            return $this->registry->call($method);
+            return $this->registry->call($method, $params);
         }
         return $default;
     }
@@ -42,21 +54,23 @@ class Login
         $loginparams = [
             'horde_user' => [
                 'label' => _("Username"),
-                'type' => 'text',
+                'type'  => 'text',
                 'value' => $this->vars->horde_user,
             ],
             'horde_pass' => [
                 'label' => _("Password"),
-                'type' => 'password',
+                'type'  => 'password',
             ],
         ];
-        if ($this->secondFactorMode > 0) {
+
+        if ($this->secondFactorSupported()) {
             $loginparams['horde_secondfactor'] = [
                 'label' => _("Second Factor"),
-                'type' => $this->secondFactorMode == 1 ? 'text' : 'password',
-                'extra' => [ 'autocomplete' => 'one-time-code' ],
+                'type'  => $this->secondFactorMode === self::SECOND_FACTOR_SHOWCODE ? 'text' : 'password',
+                'extra' => ['autocomplete' => 'one-time-code'],
             ];
         }
+
         return $loginparams;
     }
 


### PR DESCRIPTION
- Harden/replace direct `$registry->call('secondfactor/blockLogin')` calls in `login.php` and `ResponsiveLoginController` with `Login::secondFactorApi()`
- Make `secondFactorApi()` public and add support for optional API call arguments
- Fix second factor mode check: use `secondFactorMode > 0` instead of `secondFactorSupported`
- Fix `$authUser` null coalescing to explicit (string) cast
- Change `$errorSecondFactor` init to 0 (prep for `Horde_Auth` reason code)