### PR TITLE
docs(registry): document resolve_hostnames performance setting

### DIFF
--- a/config/registry.local.php.dist
+++ b/config/registry.local.php.dist
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Local overrides for registry configuration.
+ *
+ * Copy this file to registry.local.php and customize as needed.
+ * This file is loaded after registry.php and can override any settings.
+ *
+ * See registry.php for available configuration options.
+ */
+
+// Example: Enable DNS resolution for client hostnames
+// ----------------------------------------------------
+// By default, DNS resolution is DISABLED for performance (blocking
+// gethostbyaddr() calls can delay requests by 5-30 seconds on failures).
+// Enable this if you need hostnames in logs instead of IP addresses.
+//
+// $this->applications['horde']['resolve_hostnames'] = true;
+
+// Example: Override application settings
+// $this->applications['imp']['status'] = 'active';

--- a/config/registry.php
+++ b/config/registry.php
@@ -64,6 +64,10 @@
  * normally do not need to be changed from the defaults (at least during an
  * initial installation):
  *
+ *   - resolve_hostnames: (boolean) Whether to perform reverse DNS lookups
+ *                        on client IP addresses. Disabling improves
+ *                        performance by avoiding blocking DNS calls.
+ *                        DEFAULT: false (disabled, use IPs in logs)
  *   - staticfs: (string) The filesystem path for dynamically created files
  *               to be statically served.
  *   - staticuri: (string) The URI for the dynamically created files to be

--- a/src/Auth/ResponsiveLoginController.php
+++ b/src/Auth/ResponsiveLoginController.php
@@ -27,7 +27,6 @@ use Horde_Variables;
  *
  * Copyright 2026 Horde LLC (http://www.horde.org/)
  *
- * @author   Claude Code Assistant
  * @category Horde
  * @license  http://www.horde.org/licenses/lgpl21 LGPL 2.1
  * @package  Horde


### PR DESCRIPTION
Document new resolve_hostnames setting in registry.php header.
Defaults to false, normally we don't want live DNS probes in the registry.
Massive performance impact if corporate loadbalancer users hit our wiki or bug tracker.
If enough such sessions block threads and workers, other users experience a slow site or outage.
