### PR TITLE
fix(auth): use REASON_LOGOUT constant instead of string in logout URLs

### DIFF
--- a/lib/View/Topbar.php
+++ b/lib/View/Topbar.php
@@ -70,7 +70,7 @@ class Horde_View_Topbar extends Horde_View
                 $session = $GLOBALS['session'] ?? null;
                 $logoutToken = $session ? $session->getToken() : '';
                 $webroot = $registry->get('webroot', 'horde');
-                $this->logoutUrl = $webroot . '/login.php?logout_reason=logout&horde_logout_token=' . urlencode($logoutToken);
+                $this->logoutUrl = $webroot . '/login.php?logout_reason=' . Horde_Auth::REASON_LOGOUT . '&horde_logout_token=' . urlencode($logoutToken);
             }
         } else {
             if ($registry->showService('login')) {

--- a/src/Portal/ResponsivePortalController.php
+++ b/src/Portal/ResponsivePortalController.php
@@ -72,7 +72,7 @@ class ResponsivePortalController implements RequestHandlerInterface
         // Generate logout URL with CSRF token from session
         $session = $GLOBALS['session'] ?? null;
         $logoutToken = $session ? $session->getToken() : '';
-        $logoutUrl = $webroot . '/login.php?logout_reason=logout&horde_logout_token=' . urlencode($logoutToken);
+        $logoutUrl = $webroot . '/login.php?logout_reason=' . Horde_Auth::REASON_LOGOUT . '&horde_logout_token=' . urlencode($logoutToken);
 
         // Get list of available applications
         $apps = $this->getApplicationList($registry);


### PR DESCRIPTION
Commit 98731eec introduced logout_reason=logout (string) in logout URLs,
but login.php compares against Horde_Auth::REASON_LOGOUT (integer 4).
This caused redirect_on_logout to never trigger for installations
that configure an alternate logout page.