### PR TITLE
fix(login): prevent array-to-string conversion attacks on both login forms

### DIFF
--- a/login.php
+++ b/login.php
@@ -591,13 +591,18 @@ if (!$is_auth && !$prefs->isLocked('language') && !empty($langs)) {
 }
 
 $passwordResetLink = '';
-$app = $vars->app ?? 'horde';
-$url = $vars->url ?? '';
-$anchor_string = $vars->anchor_string ?? '';
+// Ensure these are always strings, not arrays (in case of malicious input like ?app[]=foo)
+$app = is_string($vars->app) ? $vars->app : 'horde';
+$url = is_string($vars->url) ? $vars->url : '';
+$anchor_string = is_string($vars->anchor_string) ? $vars->anchor_string : '';
 
 // Simple escape function for the template
 $escape = function($str) {
-    return htmlspecialchars($str, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+    // Defensive: ensure we're escaping a string, not an array
+    if (is_array($str)) {
+        return ''; // or throw exception in development
+    }
+    return htmlspecialchars((string)$str, ENT_QUOTES | ENT_HTML5, 'UTF-8');
 };
 
 // Output the responsive template directly

--- a/src/Auth/ResponsiveLoginController.php
+++ b/src/Auth/ResponsiveLoginController.php
@@ -198,10 +198,10 @@ class ResponsiveLoginController implements RequestHandlerInterface
             'errorHtml' => $errorHtml,
             'logoutMessageHtml' => $logoutMessageHtml,
 
-            // Query params for redirects
-            'app' => $queryParams['app'] ?? 'horde',
-            'url' => $queryParams['url'] ?? '',
-            'anchor_string' => $queryParams['anchor_string'] ?? '',
+            // Query params for redirects - ensure they're strings, not arrays
+            'app' => is_string($queryParams['app'] ?? null) ? $queryParams['app'] : 'horde',
+            'url' => is_string($queryParams['url'] ?? null) ? $queryParams['url'] : '',
+            'anchor_string' => is_string($queryParams['anchor_string'] ?? null) ? $queryParams['anchor_string'] : '',
         ];
 
         // Create view and render


### PR DESCRIPTION
Malicious/malformed input like ?app[]=foo or ?url[]=bar could cause
$vars properties to be arrays instead of strings.
This fix prevents code from crashing from it.
