### PR TITLE
fix: #54 Recent versions stored lastlogin as a class

### DIFF
--- a/lib/LoginTasks/Task/LastLogin.php
+++ b/lib/LoginTasks/Task/LastLogin.php
@@ -41,6 +41,13 @@ class Horde_LoginTasks_Task_LastLogin extends Horde_LoginTasks_Task
         /* Fetch the user's last login time. */
         $old_login = @unserialize($prefs->getValue('last_login'));
 
+        // Normalize host field: handle both string and Net_DNS2\Data\Domain object.
+        // Historical data may contain Net_DNS2\Data\Domain objects from PTR queries.
+        // Ensure string format for consistent behavior across Horde versions.
+        if (is_array($old_login) && isset($old_login['host']) && is_object($old_login['host'])) {
+            $old_login['host'] = (string) $old_login['host'];
+        }
+
         /* Set the timezone to the current default. */
         $registry->setTimeZone();
 
@@ -80,8 +87,10 @@ class Horde_LoginTasks_Task_LastLogin extends Horde_LoginTasks_Task
             $ptrdname = @gethostbyaddr($host);
         }
 
+        // Explicitly cast to string to prevent Net_DNS2\Data\Domain objects
+        // from being serialized. This ensures cross-version compatibility.
         $prefs->setValue('last_login', serialize([
-            'host' => $ptrdname,
+            'host' => (string) $ptrdname,
             'time' => time(),
         ]));
     }


### PR DESCRIPTION
Older versions expect a string. Support loading both variants and always store as string.