### PR TITLE
Fix/Ajax download

### DIFF
--- a/config/routes.php
+++ b/config/routes.php
@@ -516,3 +516,12 @@ $mapper->buildRoute(uri: '/services/ajax.php/:app/ajax/:qualifiedMethod', name: 
     ])
     ->withMethods(['GET', 'POST'])
     ->add();
+
+// Download service route for routed (Rampage) requests.
+// Keeps classic /services/download/ query contract (app, fn, token, ...).
+$mapper->buildRoute(uri: '/services/download/', name: 'DownloadService')
+    ->withController(DownloadController::class)
+    ->withDefaults(['HordeAuthType' => 'NONE'])
+    ->withSecondaryRoute('/services/download')
+    ->withMethods(['GET', 'POST'])
+    ->add();

--- a/src/DownloadController.php
+++ b/src/DownloadController.php
@@ -2,6 +2,28 @@
 
 declare(strict_types=1);
 
+/**
+ * PSR-15 controller for download service dispatch.
+ *
+ * Replicates the logic of services/download/index.php as a RequestHandler:
+ * build Variables from query/body, call the target app's legacy
+ * download method via registry->callAppMethod(), and return a PSR-7
+ * response with download headers and body payload.
+ *
+ * services/download/index.php is NOT modified — this controller is an
+ * alternative entry point reachable when traffic goes through the
+ * PSR-15 router.
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (LGPL). If you
+ * did not receive this file, see http://www.horde.org/licenses/lgpl21.
+ *
+ * @author    Torben Dannhauer <torben@dannhauer.de>
+ * @category  Horde
+ * @package   Horde
+ * @license   http://www.horde.org/licenses/lgpl21 LGPL 2.1
+ */
+
 namespace Horde\Horde;
 
 use Horde\Util\Variables;
@@ -13,11 +35,6 @@ use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use Throwable;
 
-/**
- * PSR-15 controller for Horde download service requests.
- *
- * Mirrors services/download/index.php behavior for routed traffic.
- */
 class DownloadController implements RequestHandlerInterface
 {
     public function __construct(

--- a/src/DownloadController.php
+++ b/src/DownloadController.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Horde\Horde;
+
+use Horde\Util\Variables;
+use Horde_Registry;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Throwable;
+
+/**
+ * PSR-15 controller for Horde download service requests.
+ *
+ * Mirrors services/download/index.php behavior for routed traffic.
+ */
+class DownloadController implements RequestHandlerInterface
+{
+    public function __construct(
+        private readonly Horde_Registry $registry,
+        private readonly ResponseFactoryInterface $responseFactory,
+        private readonly StreamFactoryInterface $streamFactory,
+    ) {}
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $query = $request->getQueryParams();
+        $body = $request->getParsedBody();
+        $params = is_array($body) ? array_merge($query, $body) : $query;
+        $vars = new Variables($params);
+
+        if (!isset($vars->app)) {
+            return $this->responseFactory->createResponse(400, 'Missing app parameter');
+        }
+
+        if (isset($vars->fn)) {
+            $vars->filename = ltrim((string) $vars->fn, '/');
+            unset($vars->fn);
+        }
+
+        try {
+            $res = $this->registry->callAppMethod($vars->app, 'download', [
+                'args' => [$vars],
+            ]);
+        } catch (Throwable) {
+            return $this->responseFactory->createResponse(404, 'Download failed');
+        }
+
+        if (!is_array($res) || !array_key_exists('data', $res)) {
+            return $this->responseFactory->createResponse(404, 'Download not found');
+        }
+
+        $filename = $res['name'] ?? ($vars->filename ?? 'download');
+        $type = $res['type'] ?? 'application/octet-stream';
+
+        if (is_resource($res['data'])) {
+            $tmp = fopen('php://temp', 'w+b');
+            if ($tmp === false) {
+                return $this->responseFactory->createResponse(500, 'Cannot stream download');
+            }
+            rewind($res['data']);
+            stream_copy_to_stream($res['data'], $tmp);
+            fclose($res['data']);
+            rewind($tmp);
+            $data = stream_get_contents($tmp);
+            fclose($tmp);
+        } else {
+            $data = (string) $res['data'];
+        }
+
+        $size = array_key_exists('size', $res) ? (int) $res['size'] : strlen($data);
+        $dispositionName = str_replace(['"', "\r", "\n"], ['_', '', ''], (string) $filename);
+
+        $response = $this->responseFactory->createResponse(200)
+            ->withHeader('Content-Type', $type)
+            ->withHeader('Content-Disposition', 'attachment; filename="' . $dispositionName . '"')
+            ->withHeader('Content-Length', (string) $size)
+            ->withHeader('Cache-Control', 'private, max-age=0, must-revalidate')
+            ->withBody($this->streamFactory->createStream($data));
+
+        return $response;
+    }
+}
+


### PR DESCRIPTION
## Summary
This PR adds PSR-15-compatible download handling for routed requests by introducing a dedicated download controller and wiring explicit download routes in Horde routing config.
### Context / Problem
Attachment downloads in routed/mobile flows could fall through the middleware stack and end in a generic fallback response (`No Response by middleware or payload Handler`) when no matching download endpoint was resolved in the PSR-15 path.
Historically, downloads were handled by the legacy script endpoint (`services/download/index.php`). As traffic increasingly goes through the router/middleware pipeline, that behavior needed an equivalent PSR-15 entry point.
## Changes
### `vendor/horde/horde/config/routes.php`
Added an explicit download service route in Horde routes:
- Primary route: `/services/download/`
- Secondary route: `/services/download` (no trailing slash variant)
- Controller: `DownloadController::class`
- Defaults: `HordeAuthType => 'NONE'`
- Methods: `GET`, `POST`
**Why this matters**
- Ensures routed requests for download URLs are matched deterministically.
- Handles both trailing-slash and no-slash URL forms.
- Avoids route miss/fallback behavior in Rampage middleware flow.
### `vendor/horde/horde/src/DownloadController.php` (new file)
Introduced a dedicated PSR-15 request handler for download service dispatch.
**What it does**
- Implements `Psr\Http\Server\RequestHandlerInterface`.
- Merges query/body parameters into `Variables` (legacy-compatible input shape).
- Reads and normalizes `fn` into `filename`.
- Delegates to legacy app download logic via:
  - `$registry->callAppMethod($vars->app, 'download', ['args' => [$vars]])`
- Returns a PSR-7 response with download semantics:
  - `Content-Type`
  - `Content-Disposition`
  - `Content-Length`
  - `Cache-Control`
  - response body payload (string/resource paths handled)
**Why a separate controller**
- Keeps concerns separated:
  - `AjaxDispatchController` = AJAX dispatch/envelope flow
  - `DownloadController` = binary/file response flow
- Better maintainability and clearer responsibility boundaries.
- Cleaner fit to PSR-15 architecture than embedding binary-download behavior into AJAX dispatch code.
## Behavioral Impact
- Download requests routed through PSR-15 now receive a valid download response instead of middleware fallback.
- Route matching is more robust due to dual `/services/download` + `/services/download/` support.
- Legacy download behavior is preserved in spirit by delegating to existing app-level `download` API methods.
## Backward Compatibility / Risk
- Additive change (new controller + new routes), no removal of legacy script endpoint.
- Minimal risk to non-download flows.
- Main risk surface is header/body behavior differences vs legacy script in edge cases; implementation mirrors expected semantics.
## Validation Performed
- PHP syntax checks passed for:
  - `vendor/horde/horde/config/routes.php`
  - `vendor/horde/horde/src/DownloadController.php`
- No linter errors in touched files.
## Test Plan
- [ ] Open attachment download URLs with and without trailing slash route shape.
- [ ] Verify downloads for common MIME types (`application/pdf`, images, generic binary).
- [ ] Verify valid/invalid token and app combinations behave as expected.
- [ ] Confirm no regression in existing AJAX endpoints (`/services/ajax.php/...`).
