### PR TITLE
feat(conf): add Redis ACL username and sentinel password fields

### DIFF
--- a/config/conf.xml
+++ b/config/conf.xml
@@ -2202,10 +2202,15 @@ cookie policy. See session configuration options.">$_SERVER['SERVER_NAME'] ?? $_
          <case name="none" desc="None" />
          <case name="sentinel" desc="Sentinel">
           <configstring name="service" required="true" desc="Name of the Service">mymaster</configstring>
+          <configstring name="sentinelPassword" required="false" desc="Password
+          to authenticate to Sentinel nodes (if different from data node
+          password)."/>
          </case>
         </configswitch>
        </case>
       </configswitch>
+      <configstring name="username" required="false" desc="Redis 6+ ACL
+      username (leave empty for default user)."/>
       <configstring name="password" required="false" desc="Password to
       authenticate to the Redis server with."/>
       <configinteger name="database" required="false" desc="Database


### PR DESCRIPTION
## Summary

- Add `username` field (Redis 6+ ACL) to hashtable Predis config section
- Add `sentinelPassword` field inside sentinel case for separate sentinel node authentication
- Companion PRs: horde/HashTable#4, horde/Core#125

Refs https://github.com/horde/HashTable/issues/3