### PR TITLE
refactor/migrate to modern hashtable and sessions

### DIFF
--- a/.horde.yml
+++ b/.horde.yml
@@ -73,6 +73,7 @@ dependencies:
       horde/autoloader: ^3
       horde/browser: ^3
       horde/core: ^3.0.0beta9
+      horde/cache: ^3
       horde/date: ^3
       horde/exception: ^3
       horde/form: ^3

--- a/composer.json
+++ b/composer.json
@@ -70,7 +70,8 @@
         "ext-gettext": "*",
         "ext-mbstring": "*",
         "ext-hash": "*",
-        "ext-intl": "*"
+        "ext-intl": "*",
+        "horde/cache": "^3.0@dev"
     },
     "require-dev": {
         "horde/test": "^3 || dev-FRAMEWORK_6_0"
@@ -135,5 +136,6 @@
         "branch-alias": {
             "dev-FRAMEWORK_6_0": "6.x-dev"
         }
-    }
+    },
+    "minimum-stability": "dev"
 }

--- a/lib/Application.php
+++ b/lib/Application.php
@@ -23,6 +23,7 @@ if (!defined('HORDE_CORE_LOADED')) {
     require_once __DIR__ . '/core.php';
 }
 use Horde\Backup;
+use Horde\Core\Session\HordeSession;
 use Horde\Horde\Factory\AuditServiceFactory;
 use Horde\Horde\Factory\LoginServiceFactory;
 use Horde\Horde\Factory\RedirectValidationServiceFactory;
@@ -123,7 +124,9 @@ if (!class_exists('Horde_Application')) {
         public function logout()
         {
             // Destroy any session-only temp files (since Horde_Core 1.7.0).
-            foreach ($GLOBALS['session']->get('horde', 'gc_tempfiles', Horde_Session::TYPE_ARRAY) as $file) {
+            $gcfiles = $GLOBALS['injector']->getInstance(HordeSession::class)
+                ->getScoped('horde', 'gc_tempfiles');
+            foreach (is_array($gcfiles) ? $gcfiles : [] as $file) {
                 @unlink($file);
             }
         }

--- a/lib/Test.php
+++ b/lib/Test.php
@@ -1057,7 +1057,6 @@ class Horde_Test
             $sessionConfigured = false;
             $configuredType = 'not configured';
             $configuredHashtable = null;
-            $actualHandler = null;
             $cookieWarning = '';
 
             // Check cookie domain configuration
@@ -1083,103 +1082,91 @@ class Horde_Test
                 }
             }
 
-            if (isset($GLOBALS['session'])) {
-                $session = $GLOBALS['session'];
-                if ($session && $session->sessionHandler) {
-                    $actualHandler = get_class($session->sessionHandler);
+            // Resolve the modern save handler from the injector. Registry's
+            // bootstrap installs Horde\SessionHandler\SessionHandler via
+            // session_set_save_handler(); the injector has it bound through
+            // SessionHandlerFactory.
+            $handler = null;
+            if (isset($GLOBALS['injector'])) {
+                try {
+                    $handler = $GLOBALS['injector']->getInstance(\Horde\SessionHandler\SessionHandler::class);
+                } catch (Exception $e) {
+                    // Fall through to the "not initialized" branch below.
+                }
+            }
 
-                    $details = "Configured: <code>{$configuredType}</code>";
-                    if ($configuredHashtable !== null) {
-                        $details .= " (hashtable: " . ($configuredHashtable ? 'yes' : 'no') . ")";
-                    }
-                    $details .= ", Active: <code>{$actualHandler}</code>";
+            if ($handler !== null) {
+                $details = "Configured: <code>{$configuredType}</code>";
+                if ($configuredHashtable !== null) {
+                    $details .= " (hashtable: " . ($configuredHashtable ? 'yes' : 'no') . ")";
+                }
+                $details .= ", Active: <code>" . htmlspecialchars(\Horde\SessionHandler\SessionHandler::class) . "</code>";
 
-                    // Check if this is Horde_SessionHandler wrapper and introspect the storage backend
-                    $storageClass = null;
-                    if ($actualHandler === 'Horde_SessionHandler') {
-                        try {
-                            $reflection = new ReflectionClass($session->sessionHandler);
-                            if ($reflection->hasProperty('_storage')) {
-                                $storageProperty = $reflection->getProperty('_storage');
-                                $storageProperty->setAccessible(true);
-                                $storageBackend = $storageProperty->getValue($session->sessionHandler);
+                // Reflect on the modern handler's storage backend.
+                $storageClass = null;
+                try {
+                    $reflection = new ReflectionClass($handler);
+                    if ($reflection->hasProperty('backend')) {
+                        $backendProperty = $reflection->getProperty('backend');
+                        $backendProperty->setAccessible(true);
+                        $storageBackend = $backendProperty->getValue($handler);
 
-                                if ($storageBackend !== null) {
-                                    $storageClass = get_class($storageBackend);
-                                    $details = "Configured: <code>{$configuredType}</code>";
-                                    if ($configuredHashtable !== null) {
-                                        $details .= " (hashtable: " . ($configuredHashtable ? 'yes' : 'no') . ")";
-                                    }
-                                    $details .= ", Active: <code>Horde_SessionHandler</code> wrapping <code>{$storageClass}</code>";
-                                }
-                            }
-                        } catch (ReflectionException $e) {
-                            // Reflection failed, just show the wrapper class
+                        if ($storageBackend !== null) {
+                            $storageClass = get_class($storageBackend);
+                            $details .= " wrapping <code>" . htmlspecialchars($storageClass) . "</code>";
                         }
                     }
+                } catch (ReflectionException $e) {
+                    // Reflection failed, just show the wrapper class
+                }
 
-                    // Check if configuration matches reality
-                    // When checking wrapped handlers, use the storage class instead of the wrapper
-                    $handlerToCheck = $storageClass ?? $actualHandler;
-                    $matches = true;
-                    if ($configuredType === 'Builtin' && !preg_match('/Builtin/i', $handlerToCheck)) {
-                        $matches = false;
-                    } elseif ($configuredType === 'External' && !preg_match('/External/i', $handlerToCheck)) {
-                        $matches = false;
-                    }
+                // Check if configuration matches reality. The modern factory
+                // resolves these driver names to namespaced backend classes
+                // (Builtin -> BuiltinBackend, etc.), so substring match still
+                // works the way it used to.
+                $handlerToCheck = $storageClass ?? \Horde\SessionHandler\SessionHandler::class;
+                $matches = true;
+                if ($configuredType === 'Builtin' && !preg_match('/Builtin/i', $handlerToCheck)) {
+                    $matches = false;
+                } elseif ($configuredType === 'External' && !preg_match('/External/i', $handlerToCheck)) {
+                    $matches = false;
+                }
 
-                    if ($cookieWarning) {
-                        $output .= $this->_outputLine([
-                            'Session Handler',
-                            $this->_status(true, false),
-                            $details . $cookieWarning,
-                            true,  // Orange warning
-                        ]);
-                    } elseif ($matches) {
-                        $output .= $this->_outputLine([
-                            'Session Handler',
-                            $this->_status(true),
-                            $details,
-                            'green',
-                        ]);
-                    } else {
-                        $output .= $this->_outputLine([
-                            'Session Handler',
-                            $this->_status(true, false),
-                            "{$details} - Configuration mismatch warning",
-                            true,  // Orange warning
-                        ]);
-                    }
+                if ($cookieWarning) {
+                    $output .= $this->_outputLine([
+                        'Session Handler',
+                        $this->_status(true, false),
+                        $details . $cookieWarning,
+                        true,  // Orange warning
+                    ]);
+                } elseif ($matches) {
+                    $output .= $this->_outputLine([
+                        'Session Handler',
+                        $this->_status(true),
+                        $details,
+                        'green',
+                    ]);
                 } else {
-                    if ($sessionConfigured) {
-                        $output .= $this->_outputLine([
-                            'Session Handler',
-                            $this->_status(false, false),
-                            "Configured: <code>{$configuredType}</code> but session handler not fully initialized (may be in CLI/test mode)" . $cookieWarning,
-                            true,  // Orange warning
-                        ]);
-                    } else {
-                        $output .= $this->_outputLine([
-                            'Session Handler',
-                            $this->_status(false, false),
-                            'Session handler not fully initialized and not configured in conf.php' . $cookieWarning,
-                            true,  // Orange warning
-                        ]);
-                    }
+                    $output .= $this->_outputLine([
+                        'Session Handler',
+                        $this->_status(true, false),
+                        "{$details} - Configuration mismatch warning",
+                        true,  // Orange warning
+                    ]);
                 }
             } else {
                 if ($sessionConfigured) {
                     $output .= $this->_outputLine([
                         'Session Handler',
                         $this->_status(false, false),
-                        "Configured: <code>{$configuredType}</code> but session not available in global scope" . $cookieWarning,
+                        "Configured: <code>{$configuredType}</code> but session handler not available from injector (may be in CLI/test mode)" . $cookieWarning,
                         true,  // Orange warning
                     ]);
                 } else {
                     $output .= $this->_outputLine([
                         'Session Handler',
                         $this->_status(false, false),
-                        'Session not available and no sessionhandler configuration found in conf.php' . $cookieWarning,
+                        'Session handler not available from injector and not configured in conf.php' . $cookieWarning,
                         true,  // Orange warning
                     ]);
                 }

--- a/src/Auth/AuthApiController.php
+++ b/src/Auth/AuthApiController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Horde\Horde\Auth;
 
+use Horde\Core\Auth\AuthCredentialStore;
 use Horde\Horde\Service\AuthenticationService;
 use Horde\Horde\Traits\JsonResponseTrait;
 use Psr\Http\Message\ResponseInterface;
@@ -57,7 +58,8 @@ class AuthApiController implements RequestHandlerInterface
             // If JWT bootstrap wasn't loaded, create service manually
             $registry = $injector->getInstance('Horde_Registry');
             $logger = $injector->getInstance(LoggerInterface::class);
-            $this->authService = new AuthenticationService($registry, $logger, null);
+            $credentialStore = $injector->getInstance(AuthCredentialStore::class);
+            $this->authService = new AuthenticationService($registry, $logger, $credentialStore);
         }
     }
 

--- a/src/Auth/ResponsiveLoginController.php
+++ b/src/Auth/ResponsiveLoginController.php
@@ -6,6 +6,7 @@ namespace Horde\Horde\Auth;
 
 use Exception;
 use Horde\Core\Config\RegistryConfigLoader;
+use Horde\Core\Session\HordeSession;
 use Horde\Horde\Service\LoginService;
 use Horde\Horde\Service\RedirectValidationService;
 use Horde\Horde\Traits\HtmlResponseTrait;
@@ -198,11 +199,12 @@ class ResponsiveLoginController implements RequestHandlerInterface
 
             // Store tokens in session flash for JS to read once
             if ($result->accessToken !== null) {
-                $_SESSION['__horde']['jwt_bootstrap'] = [
-                    'access_token' => $result->accessToken,
-                    'refresh_token' => $result->refreshToken,
-                    'expires_at' => $result->expiresAt,
-                ];
+                $GLOBALS['injector']->getInstance(HordeSession::class)
+                    ->setScoped('horde', 'jwt_bootstrap', [
+                        'access_token' => $result->accessToken,
+                        'refresh_token' => $result->refreshToken,
+                        'expires_at' => $result->expiresAt,
+                    ]);
             }
         }
 

--- a/src/Factory/AuthenticationServiceFactory.php
+++ b/src/Factory/AuthenticationServiceFactory.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Horde\Horde\Factory;
 
+use Horde\Core\Auth\AuthCredentialStore;
 use Horde\Horde\Service\AuthenticationService;
 use Horde\Horde\Service\JwtService;
 use Horde\Injector\Injector;
@@ -37,6 +38,7 @@ class AuthenticationServiceFactory
     {
         $registry = $injector->getInstance('Horde_Registry');
         $logger = $injector->getInstance(LoggerInterface::class);
+        $credentialStore = $injector->getInstance(AuthCredentialStore::class);
 
         // Try to get JWT service (may be null if not configured)
         $jwtService = null;
@@ -48,6 +50,6 @@ class AuthenticationServiceFactory
             // AuthenticationService will fall back to session-only mode
         }
 
-        return new AuthenticationService($registry, $logger, $jwtService);
+        return new AuthenticationService($registry, $logger, $jwtService, $credentialStore);
     }
 }

--- a/src/Factory/AuthenticationServiceFactory.php
+++ b/src/Factory/AuthenticationServiceFactory.php
@@ -50,6 +50,6 @@ class AuthenticationServiceFactory
             // AuthenticationService will fall back to session-only mode
         }
 
-        return new AuthenticationService($registry, $logger, $jwtService, $credentialStore);
+        return new AuthenticationService($registry, $logger, $credentialStore, $jwtService);
     }
 }

--- a/src/Portal/ResponsivePortalController.php
+++ b/src/Portal/ResponsivePortalController.php
@@ -6,6 +6,7 @@ namespace Horde\Horde\Portal;
 
 use Horde\Core\Assets\ResponsiveAssets;
 use Horde\Core\Config\RegistryState;
+use Horde\Core\Session\HordeSession;
 use Horde\Core\View\ResponsiveTemplateView;
 use Horde\Horde\Traits\HtmlResponseTrait;
 use Horde\Horde\Traits\RedirectResponseTrait;
@@ -79,11 +80,12 @@ class ResponsivePortalController implements RequestHandlerInterface
         $apps = $this->getApplicationList($registry);
 
         // Check for JWT bootstrap tokens from login
-        $jwtBootstrap = $_SESSION['__horde']['jwt_bootstrap'] ?? null;
+        $hordeSession = $GLOBALS['injector']->getInstance(HordeSession::class);
+        $jwtBootstrap = $hordeSession->getScoped('horde', 'jwt_bootstrap');
         $jwtBootstrapJson = $jwtBootstrap ? json_encode($jwtBootstrap, JSON_THROW_ON_ERROR) : 'null';
         // Clear the flash data after reading
         if ($jwtBootstrap) {
-            unset($_SESSION['__horde']['jwt_bootstrap']);
+            $hordeSession->removeScoped('horde', 'jwt_bootstrap');
         }
 
         // Build view data for template

--- a/src/Service/AuthenticationService.php
+++ b/src/Service/AuthenticationService.php
@@ -59,35 +59,23 @@ use Horde;
 class AuthenticationService
 {
     /**
-     * @param Horde_Registry            $registry         Horde registry
-     * @param LoggerInterface           $logger           PSR-3 logger
-     * @param JwtService|null           $jwtService       JWT service (optional, for dual-mode)
-     * @param AuthCredentialStore|null  $credentialStore  Credentials store. If
-     *                                                    omitted, resolved
-     *                                                    lazily from the global
-     *                                                    injector for BC.
+     * @param Horde_Registry      $registry         Horde registry.
+     * @param LoggerInterface     $logger           PSR-3 logger.
+     * @param AuthCredentialStore $credentialStore  Modern credentials store
+     *                                              owning the auth_app/<app>
+     *                                              session slot. Modern read
+     *                                              path for paths that recover
+     *                                              an authenticated user's
+     *                                              credentials.
+     * @param JwtService|null     $jwtService       JWT service (optional, for
+     *                                              dual-mode).
      */
     public function __construct(
         private readonly Horde_Registry $registry,
         private readonly LoggerInterface $logger,
+        private readonly AuthCredentialStore $credentialStore,
         private readonly ?JwtService $jwtService = null,
-        private ?AuthCredentialStore $credentialStore = null,
     ) {}
-
-    /**
-     * Resolve the credential store lazily so legacy constructions
-     * (`new AuthenticationService($registry, $logger, $jwt)`) keep working
-     * without explicit injection.
-     */
-    private function credentialStore(): AuthCredentialStore
-    {
-        if ($this->credentialStore === null) {
-            $this->credentialStore = $GLOBALS['injector']->getInstance(
-                AuthCredentialStore::class
-            );
-        }
-        return $this->credentialStore;
-    }
 
     /**
      * Authenticate a user with username and password
@@ -396,7 +384,7 @@ class AuthenticationService
         // Recover credentials from the canonical store. Registry's
         // setAuth/setAuthCredential plumbing writes them through the same
         // store, so any authenticated user has them available here.
-        $credentials = $this->credentialStore()->get(null);
+        $credentials = $this->credentialStore->get(null);
         if (!is_array($credentials)) {
             throw new Exception('No credentials available for authenticated user');
         }

--- a/src/Service/AuthenticationService.php
+++ b/src/Service/AuthenticationService.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Horde\Horde\Service;
 
+use Horde\Core\Auth\AuthCredentialStore;
 use Horde\Core\Auth\Jwt\GeneratedJwt;
 use Horde_Registry;
 use Psr\Log\LoggerInterface;
@@ -58,15 +59,35 @@ use Horde;
 class AuthenticationService
 {
     /**
-     * @param Horde_Registry $registry Horde registry
-     * @param LoggerInterface $logger PSR-3 logger
-     * @param JwtService|null $jwtService JWT service (optional, for dual-mode)
+     * @param Horde_Registry            $registry         Horde registry
+     * @param LoggerInterface           $logger           PSR-3 logger
+     * @param JwtService|null           $jwtService       JWT service (optional, for dual-mode)
+     * @param AuthCredentialStore|null  $credentialStore  Credentials store. If
+     *                                                    omitted, resolved
+     *                                                    lazily from the global
+     *                                                    injector for BC.
      */
     public function __construct(
         private readonly Horde_Registry $registry,
         private readonly LoggerInterface $logger,
         private readonly ?JwtService $jwtService = null,
+        private ?AuthCredentialStore $credentialStore = null,
     ) {}
+
+    /**
+     * Resolve the credential store lazily so legacy constructions
+     * (`new AuthenticationService($registry, $logger, $jwt)`) keep working
+     * without explicit injection.
+     */
+    private function credentialStore(): AuthCredentialStore
+    {
+        if ($this->credentialStore === null) {
+            $this->credentialStore = $GLOBALS['injector']->getInstance(
+                AuthCredentialStore::class
+            );
+        }
+        return $this->credentialStore;
+    }
 
     /**
      * Authenticate a user with username and password
@@ -372,10 +393,12 @@ class AuthenticationService
             throw new Exception('User not authenticated');
         }
 
-        // Get current session data (credentials) before switching sessions
-        $credentials = $_SESSION['__horde']['auth']['credentials'] ?? null;
-        if (!$credentials) {
-            throw new Exception('No credentials in session');
+        // Recover credentials from the canonical store. Registry's
+        // setAuth/setAuthCredential plumbing writes them through the same
+        // store, so any authenticated user has them available here.
+        $credentials = $this->credentialStore()->get(null);
+        if (!is_array($credentials)) {
+            throw new Exception('No credentials available for authenticated user');
         }
 
         // Generate refresh token (JTI will be new session ID)

--- a/src/Service/Health/HealthCheckService.php
+++ b/src/Service/Health/HealthCheckService.php
@@ -19,8 +19,9 @@ namespace Horde\Horde\Service\Health;
 use Horde_Db_Adapter;
 use Horde_Cache;
 use Horde_Log_Logger;
-use Horde_Session;
+use Horde\Core\Session\HordeSession;
 use Horde\Injector\Injector;
+use Horde\SessionHandler\SessionHandler;
 use Exception;
 use ReflectionClass;
 use ReflectionException;
@@ -192,27 +193,27 @@ class HealthCheckService
     {
         try {
             $conf = $GLOBALS['conf'] ?? [];
-            $session = $GLOBALS['session'] ?? null;
-
             $configuredType = $conf['sessionhandler']['type'] ?? 'not configured';
             $configuredHashtable = $conf['sessionhandler']['hashtable'] ?? null;
 
-            if (!$session || !$session->sessionHandler) {
+            try {
+                $handler = $this->injector->getInstance(SessionHandler::class);
+            } catch (Exception $e) {
                 return [
                     'status' => 'warning',
-                    'message' => 'Session handler not fully initialized (may be CLI mode)',
+                    'message' => 'Session handler not available from injector (may be CLI mode)',
                     'details' => [
                         'configured_type' => $configuredType,
                         'configured_hashtable' => $configuredHashtable,
+                        'error' => $e->getMessage(),
                     ],
                 ];
             }
 
-            $actualHandler = get_class($session->sessionHandler);
             $details = [
                 'configured_type' => $configuredType,
                 'configured_hashtable' => $configuredHashtable,
-                'actual_handler' => $actualHandler,
+                'actual_handler' => SessionHandler::class,
             ];
 
             // Check for cookie domain issues
@@ -231,22 +232,29 @@ class HealthCheckService
                 ];
             }
 
-            // Introspect storage backend if Horde_SessionHandler wrapper
-            if ($actualHandler === 'Horde_SessionHandler') {
-                try {
-                    $reflection = new ReflectionClass($session->sessionHandler);
-                    if ($reflection->hasProperty('_storage')) {
-                        $storageProperty = $reflection->getProperty('_storage');
-                        $storageProperty->setAccessible(true);
-                        $storageBackend = $storageProperty->getValue($session->sessionHandler);
+            // Introspect the modern handler's storage backend via reflection.
+            // The backend property is private readonly on SessionHandler.
+            try {
+                $reflection = new ReflectionClass($handler);
+                if ($reflection->hasProperty('backend')) {
+                    $backendProperty = $reflection->getProperty('backend');
+                    $backendProperty->setAccessible(true);
+                    $storageBackend = $backendProperty->getValue($handler);
 
-                        if ($storageBackend !== null) {
-                            $details['storage_backend'] = get_class($storageBackend);
-                        }
+                    if ($storageBackend !== null) {
+                        $details['storage_backend'] = get_class($storageBackend);
                     }
-                } catch (ReflectionException $e) {
-                    // Reflection failed, skip storage backend details
                 }
+            } catch (ReflectionException $e) {
+                // Reflection failed, skip storage backend details
+            }
+
+            // Confirm the modern session data layer is also resolvable.
+            try {
+                $this->injector->getInstance(HordeSession::class);
+                $details['session_data_layer'] = HordeSession::class;
+            } catch (Exception $e) {
+                $details['session_data_layer'] = 'unavailable: ' . $e->getMessage();
             }
 
             return [

--- a/test/Integration/Login/LoginParityTest.php
+++ b/test/Integration/Login/LoginParityTest.php
@@ -322,10 +322,10 @@ class LoginParityTest extends TestCase
             $sessionId = $this->extractSessionId($response);
             $sessionData = $this->readSessionData($sessionId);
 
-            $this->assertArrayHasKey('__horde', $sessionData, "$endpoint session should have __horde key");
-            $this->assertArrayHasKey('jwt_bootstrap', $sessionData['__horde'], "$endpoint session should have jwt_bootstrap");
+            $this->assertArrayHasKey('horde', $sessionData, "$endpoint session should have horde scope");
+            $this->assertArrayHasKey('jwt_bootstrap', $sessionData['horde'], "$endpoint session should have jwt_bootstrap");
 
-            $jwt = $sessionData['__horde']['jwt_bootstrap'];
+            $jwt = $sessionData['horde']['jwt_bootstrap'];
             $this->assertArrayHasKey('access_token', $jwt, "$endpoint should have access_token");
             $this->assertArrayHasKey('refresh_token', $jwt, "$endpoint should have refresh_token");
             $this->assertArrayHasKey('expires_at', $jwt, "$endpoint should have expires_at");

--- a/test/Unit/Factory/AuthenticationServiceFactoryTest.php
+++ b/test/Unit/Factory/AuthenticationServiceFactoryTest.php
@@ -6,6 +6,7 @@ namespace Horde\Horde\Test\Unit\Factory;
 
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
+use Horde\Core\Auth\AuthCredentialStore;
 use Horde\Horde\Factory\AuthenticationServiceFactory;
 use Horde\Horde\Factory\JwtServiceFactory;
 use Horde\Horde\Service\AuthenticationService;
@@ -41,12 +42,19 @@ class AuthenticationServiceFactoryTest extends TestCase
         // Create mock logger
         $logger = $this->createMock(LoggerInterface::class);
 
+        // Create mock credentials store. The factory passes it through to
+        // AuthenticationService construction; no methods are called on it
+        // during factory create().
+        $credentialStore = $this->createMock(AuthCredentialStore::class);
+        $credentialStore->expects($this->never())->method($this->anything());
+
         // Create mock injector
         $this->injector = $this->createMock(Injector::class);
         $this->injector->method('getInstance')
             ->willReturnMap([
                 ['Horde_Registry', $this->registry],
                 [LoggerInterface::class, $logger],
+                [AuthCredentialStore::class, $credentialStore],
             ]);
     }
 

--- a/test/Unit/Service/AuthenticationServiceJtiSessionTest.php
+++ b/test/Unit/Service/AuthenticationServiceJtiSessionTest.php
@@ -61,8 +61,17 @@ class AuthenticationServiceJtiSessionTest extends TestCase
         $jwtService->method('verifyRefreshToken')
             ->willReturn($mockVerified);
 
-        // Create service
-        $authService = new AuthenticationService($registry, $this->createMock(LoggerInterface::class), $jwtService);
+        // Create service. refreshToken doesn't touch the credential store —
+        // pin that as a contract.
+        $credentialStore = $this->createMock(AuthCredentialStore::class);
+        $credentialStore->expects($this->never())->method($this->anything());
+
+        $authService = new AuthenticationService(
+            $registry,
+            $this->createMock(LoggerInterface::class),
+            $credentialStore,
+            $jwtService,
+        );
 
         // Try to refresh
         $result = $authService->refreshToken('fake-jwt-token');
@@ -136,8 +145,17 @@ class AuthenticationServiceJtiSessionTest extends TestCase
         $jwtService->method('generateAccessToken')
             ->willReturn($mockAccessToken);
 
-        // Create service
-        $authService = new AuthenticationService($registry, $this->createMock(LoggerInterface::class), $jwtService);
+        // Create service. refreshToken doesn't touch the credential store —
+        // pin that as a contract.
+        $credentialStore = $this->createMock(AuthCredentialStore::class);
+        $credentialStore->expects($this->never())->method($this->anything());
+
+        $authService = new AuthenticationService(
+            $registry,
+            $this->createMock(LoggerInterface::class),
+            $credentialStore,
+            $jwtService,
+        );
 
         // Try to refresh with attacker's token
         // The method will:
@@ -170,8 +188,17 @@ class AuthenticationServiceJtiSessionTest extends TestCase
         $registry->expects($this->once())
             ->method('clearAuth');
 
-        // Create service
-        $authService = new AuthenticationService($registry, $this->createMock(LoggerInterface::class), null);
+        // Create service. logout doesn't touch the credential store — pin
+        // that as a contract.
+        $credentialStore = $this->createMock(AuthCredentialStore::class);
+        $credentialStore->expects($this->never())->method($this->anything());
+
+        $authService = new AuthenticationService(
+            $registry,
+            $this->createMock(LoggerInterface::class),
+            $credentialStore,
+            null,
+        );
 
         // Logout
         $authService->logout();
@@ -253,8 +280,8 @@ class AuthenticationServiceJtiSessionTest extends TestCase
         $authService = new AuthenticationService(
             $registry,
             $this->createMock(LoggerInterface::class),
-            $jwtService,
             $credentialStore,
+            $jwtService,
         );
 
         // Issue tokens

--- a/test/Unit/Service/AuthenticationServiceJtiSessionTest.php
+++ b/test/Unit/Service/AuthenticationServiceJtiSessionTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Horde\Horde\Test\Unit\Service;
 
 use PHPUnit\Framework\TestCase;
+use Horde\Core\Auth\AuthCredentialStore;
 use Horde\Horde\Service\AuthenticationService;
 use Horde\Horde\Service\JwtService;
 use Horde\Core\Auth\Jwt\GeneratedJwt;
@@ -187,17 +188,18 @@ class AuthenticationServiceJtiSessionTest extends TestCase
         // Mock global injector (needed by buildJwtClaims)
         $GLOBALS['injector'] = $this->createMockInjectorForPrefs();
 
-        // Start a session with credentials
+        // Start a session so session_id() / session_write_close() work.
         if (session_status() !== PHP_SESSION_ACTIVE) {
             session_start();
         }
-        $_SESSION = [
-            '__horde' => [
-                'auth' => [
-                    'credentials' => ['password' => 'testpass'],
-                ],
-            ],
-        ];
+
+        // Credentials live in the modern AuthCredentialStore. Mock it to
+        // return what the legacy registry/setAuth path would have stored.
+        $credentialStore = $this->createMock(AuthCredentialStore::class);
+        $credentialStore->expects($this->once())
+            ->method('get')
+            ->with(null)
+            ->willReturn(['password' => 'testpass']);
 
         // Mock registry
         $registry = $this->createMock(Horde_Registry::class);
@@ -247,8 +249,13 @@ class AuthenticationServiceJtiSessionTest extends TestCase
             )
             ->willReturn($mockAccessToken);
 
-        // Create service
-        $authService = new AuthenticationService($registry, $this->createMock(LoggerInterface::class), $jwtService);
+        // Create service with the mocked store injected directly.
+        $authService = new AuthenticationService(
+            $registry,
+            $this->createMock(LoggerInterface::class),
+            $jwtService,
+            $credentialStore,
+        );
 
         // Issue tokens
         $result = $authService->issueTokensForAuthenticatedUser('testuser');

--- a/test/Unit/Service/AuthenticationServiceSessionRegistryTest.php
+++ b/test/Unit/Service/AuthenticationServiceSessionRegistryTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Horde\Horde\Test\Unit\Service;
 
 use PHPUnit\Framework\TestCase;
+use Horde\Core\Auth\AuthCredentialStore;
 use Horde\Horde\Service\AuthenticationService;
 use Horde\Horde\Service\JwtService;
 use Horde\Core\Auth\Jwt\VerifiedJwt;
@@ -69,8 +70,17 @@ class AuthenticationServiceSessionRegistryTest extends TestCase
         $registry->method('getAuth')
             ->willReturn('testuser');
 
-        // Create service
-        $authService = new AuthenticationService($registry, $this->createMock(LoggerInterface::class), $jwtService);
+        // Create service. refreshToken doesn't touch the credential store —
+        // pin that as a contract.
+        $credentialStore = $this->createMock(AuthCredentialStore::class);
+        $credentialStore->expects($this->never())->method($this->anything());
+
+        $authService = new AuthenticationService(
+            $registry,
+            $this->createMock(LoggerInterface::class),
+            $credentialStore,
+            $jwtService,
+        );
 
         // Refresh token
         $result = $authService->refreshToken('fake-jwt-token');
@@ -113,8 +123,17 @@ class AuthenticationServiceSessionRegistryTest extends TestCase
         $registry->expects($this->once())
             ->method('clearAuth');
 
-        // Create service
-        $authService = new AuthenticationService($registry, $this->createMock(LoggerInterface::class), null);
+        // Create service. logout doesn't touch the credential store — pin
+        // that as a contract.
+        $credentialStore = $this->createMock(AuthCredentialStore::class);
+        $credentialStore->expects($this->never())->method($this->anything());
+
+        $authService = new AuthenticationService(
+            $registry,
+            $this->createMock(LoggerInterface::class),
+            $credentialStore,
+            null,
+        );
 
         // Logout
         $authService->logout();


### PR DESCRIPTION
This is part of the ongoing effort to move off old-style Horde_Hashtable and Horde_Session classes and also move the auth stack progressively out of the registry god object.

- **refactor(auth): Port JWT bootstrap flash data to HordeSession**
- **refactor(application): Port logout gc_tempfiles loop to HordeSession**
- **refactor(diagnostic): Port session inspection to the modern stack**
- **fix(auth): Read credentials via AuthCredentialStore in JWT issuance**
- **refactor: Make AuthCredentialStore mandatory**

  Refs horde/Core#131