### PR TITLE
refactor(token): Use Horde\Token\Token directly at four sites

### DIFF
--- a/lib/View/Topbar.php
+++ b/lib/View/Topbar.php
@@ -23,6 +23,10 @@
  * @license  http://www.horde.org/licenses/lgpl LGPL-2
  * @package  Horde
  */
+
+use Horde\Core\Session\HordeSession;
+use Horde\Token\Token;
+
 class Horde_View_Topbar extends Horde_View
 {
     /**
@@ -64,9 +68,9 @@ class Horde_View_Topbar extends Horde_View
         /* Login/Logout. */
         if ($registry->getAuth()) {
             if ($registry->showService('logout')) {
-                // Generate logout URL with CSRF token from session
-                $session = $GLOBALS['session'] ?? null;
-                $logoutToken = $session ? $session->getToken() : '';
+                // Generate logout URL with CSRF token from the modern token service.
+                $tokenService = $GLOBALS['injector']->getInstance(Token::class);
+                $logoutToken = (string) $tokenService->generate(HordeSession::CSRF_SEED);
                 $webroot = $registry->get('webroot', 'horde');
                 $this->logoutUrl = $webroot . '/login.php?logout_reason=logout&horde_logout_token=' . urlencode($logoutToken);
             }

--- a/login.php
+++ b/login.php
@@ -24,6 +24,9 @@
  * @package  Horde
  */
 
+use Horde\Core\Session\HordeSession;
+use Horde\Token\Exception\TokenException;
+use Horde\Token\Token;
 use Horde\Util\Util;
 use Horde\Util\Variables;
 use Psr\Log\LoggerInterface;
@@ -124,7 +127,18 @@ if (!$is_auth && !$prefs->isLocked('language') && $vars->new_lang) {
 if ($logout_reason) {
     if ($is_auth) {
         try {
-            $session->checkToken($vars->horde_logout_token);
+            $tokenService = $injector->getInstance(Token::class);
+            $valid = $tokenService->isValid(
+                (string) $vars->horde_logout_token,
+                HordeSession::CSRF_SEED
+            );
+            if (!$valid) {
+                throw new Horde_Exception('Invalid token!');
+            }
+        } catch (TokenException $e) {
+            $notification->push(new Horde_Exception('Invalid token!'), 'horde.error');
+            require HORDE_BASE . '/index.php';
+            exit;
         } catch (Horde_Exception $e) {
             $notification->push($e, 'horde.error');
             require HORDE_BASE . '/index.php';

--- a/src/Portal/ResponsivePortalController.php
+++ b/src/Portal/ResponsivePortalController.php
@@ -10,6 +10,7 @@ use Horde\Core\Session\HordeSession;
 use Horde\Core\View\ResponsiveTemplateView;
 use Horde\Horde\Traits\HtmlResponseTrait;
 use Horde\Horde\Traits\RedirectResponseTrait;
+use Horde\Token\Token;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
@@ -71,9 +72,9 @@ class ResponsivePortalController implements RequestHandlerInterface
         $themesUri = $registry->get('themesuri', 'horde');
         $webroot = $registry->get('webroot', 'horde');
 
-        // Generate logout URL with CSRF token from session
-        $session = $GLOBALS['session'] ?? null;
-        $logoutToken = $session ? $session->getToken() : '';
+        // Generate logout URL with CSRF token from the modern token service.
+        $tokenService = $GLOBALS['injector']->getInstance(Token::class);
+        $logoutToken = (string) $tokenService->generate(HordeSession::CSRF_SEED);
         $logoutUrl = $webroot . '/login.php?logout_reason=logout&horde_logout_token=' . urlencode($logoutToken);
 
         // Get list of available applications

--- a/src/Service/LoginService.php
+++ b/src/Service/LoginService.php
@@ -25,6 +25,9 @@ use Horde_Url;
 use Horde\Core\Assets\ResponsiveAssets;
 use Horde\Core\Config\RegistryState;
 use Horde\Core\Service\OAuthProviderConfigRepository;
+use Horde\Core\Session\HordeSession;
+use Horde\Token\Exception\TokenException;
+use Horde\Token\Token;
 use Horde\Horde\Login;
 use Horde\Horde\Factory\LoginServiceFactory;
 use Horde\Horde\ValueObject\LoginAttempt;
@@ -378,13 +381,24 @@ class LoginService
      */
     public function performLogout(LogoutRequest $request): array
     {
-        $session = $GLOBALS['session'] ?? null;
         $notification = $GLOBALS['notification'] ?? null;
 
         // CSRF verification
-        if ($session && !empty($request->csrfToken)) {
-            $session->checkToken($request->csrfToken);
+        if (!empty($request->csrfToken)) {
+            $tokenService = $GLOBALS['injector']->getInstance(Token::class);
+            try {
+                $valid = $tokenService->isValid($request->csrfToken, HordeSession::CSRF_SEED);
+            } catch (TokenException $e) {
+                throw new Horde_Exception('Invalid token!');
+            }
+            if (!$valid) {
+                throw new Horde_Exception('Invalid token!');
+            }
         }
+
+        // Pulled later for the lifecycle setup() call below — that site is
+        // still on the shim because HordeSession lacks a lifecycle surface.
+        $session = $GLOBALS['session'] ?? null;
 
         // Audit log
         $currentUser = $this->registry->getAuth();


### PR DESCRIPTION
## Summary

Four sites in horde/base switch from the shim's `getToken`/`checkToken` to `Horde\Token\Token` resolved via DI:

- `lib/View/Topbar.php` — logout link generation.
- `src/Portal/ResponsivePortalController.php` — logout link generation.
- `src/Service/LoginService.php` (`performLogout`) — logout CSRF verification.
- `login.php` — logout CSRF verification.

Each site uses `Token::generate(HordeSession::CSRF_SEED)` or `Token::isValid($t, HordeSession::CSRF_SEED)` directly. Verifiers preserve the `Horde_Exception('Invalid token!')` shape callers expect.

The shim's `getToken`/`checkToken` already route through `Horde\Token\Token` since the cutover. After horde/Core PR `refactor(token): Resolve session via HordeSession in legacy create()` lands, the legacy DI binding (`Token::class => TokenServiceFactory::class`) also reads the same per-session secret slot. Tokens generated by either path are mutually verifiable.

## Remaining

`LoginService::performLogout` keeps a single `$session = $GLOBALS['session']` lookup for the `setup()` lifecycle call later in the method. `HordeSession` has no lifecycle surface yet. Marked with an inline comment. Future work.

Refs horde/Core#131