### PR TITLE
feat(session): add /api/v1/session/whoami modern PSR-15 demo route

### DIFF
--- a/config/conf.xml
+++ b/config/conf.xml
@@ -191,6 +191,17 @@ cookie policy. See session configuration options.">$_SERVER['SERVER_NAME'] ?? $_
    http://lists.horde.org/archives/imp/Week-of-Mon-20030113/029149.html">
    /</configstring>
   </configsection>
+
+  <configheader>Session Whoami Endpoint</configheader>
+  <configsection name="session_whoami">
+   <configboolean name="public" desc="Whether the
+   /api/v1/session/whoami endpoint serves anonymous callers. When false
+   (default), unauthenticated callers receive 401. When true, anonymous
+   callers see their freshly minted session id and an empty credentials
+   map. The endpoint exists primarily for end-to-end smoke testing of
+   the modern session middleware stack. Will be replaced by a
+   permissions check once the modern permissions stack lands.">false</configboolean>
+  </configsection>
  </configtab>
 
  <configtab name="db" desc="Database">

--- a/config/routes.php
+++ b/config/routes.php
@@ -12,7 +12,9 @@ use Horde\Core\Middleware\DemandAuthenticatedUser;
 use Horde\Core\Middleware\DemandGlobalAdmin;
 use Horde\Core\Middleware\ErrorFilter;
 use Horde\Core\Middleware\HordeCore;
+use Horde\Core\Middleware\HordeSessionMiddleware;
 use Horde\Core\Middleware\JwtAuthMiddleware;
+use Horde\Core\Middleware\JwtSessionLoader;
 use Horde\Core\Middleware\OAuthConsentMiddleware;
 use Horde\Http\Server\Middleware\JsonBodyParser;
 use Horde\OAuth\Oidc\Handler\DiscoveryEndpoint;
@@ -564,4 +566,20 @@ $mapper->buildRoute(uri: '/services/download/', name: 'DownloadService')
     ->noMiddleware()
     ->withSecondaryRoute('/services/download')
     ->withMethods(['GET', 'POST'])
+    ->add();
+
+// Modern session demo route. Exercises the modern PSR-15 session
+// middleware stack end-to-end without HordeCore, AuthHordeSession, or
+// Horde_Registry. Auth gate is config-driven via
+// `$conf['session_whoami']['public']`. See
+// horde-development/strategies/modern-session-migration/session-whoami-demo-plan-2026-06-11.md.
+$mapper->buildRoute(uri: '/api/v1/session/whoami', name: 'SessionWhoami')
+    ->withController(Service\SessionWhoamiController::class)
+    ->withDefaults(['HordeAuthType' => 'NONE'])
+    ->withMiddleware([
+        ErrorFilter::class,
+        JwtSessionLoader::class,
+        HordeSessionMiddleware::class,
+    ])
+    ->withMethods(['GET'])
     ->add();

--- a/src/Service/SessionWhoamiController.php
+++ b/src/Service/SessionWhoamiController.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (LGPL). If you
+ * did not receive this file, see http://www.horde.org/licenses/lgpl21.
+ *
+ * @category  Horde
+ * @copyright 2026 The Horde Project
+ * @license   http://www.horde.org/licenses/lgpl21 LGPL 2.1
+ * @package   Horde
+ */
+
+namespace Horde\Horde\Service;
+
+use Horde\Core\Auth\AuthCredentialStore;
+use Horde\Core\Config\ConfigLoader;
+use Horde\Core\Middleware\HordeSessionMiddleware;
+use Horde\Core\Session\HordeSession;
+use Horde\Horde\Traits\JsonResponseTrait;
+use Horde\Injector\Attribute\Factory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * Modern PSR-15 demo route: GET /api/v1/session/whoami.
+ *
+ * Returns JSON describing the current session: id, authenticated user
+ * (if any), session age, per-app credential states. The endpoint
+ * exists to prove the modern session middleware stack works
+ * end-to-end without HordeCore, AuthHordeSession, or Horde_Registry.
+ *
+ * Auth gate is config-driven: when `$conf['session_whoami']['public']`
+ * is unset or false, anonymous callers receive 401. When true,
+ * anonymous callers see a populated body with their freshly minted
+ * session id and an empty credentials map.
+ *
+ * The auth gate will move to the modern permissions stack once that
+ * lands. Until then, the config switch is the smallest knob that
+ * works without legacy plumbing.
+ *
+ * @see \Horde\Horde\Service\SessionWhoamiControllerFactory
+ * @see \Horde\Core\Middleware\HordeSessionMiddleware
+ * @see \Horde\Core\Middleware\JwtSessionLoader
+ */
+#[Factory(factory: SessionWhoamiControllerFactory::class, method: 'create')]
+final class SessionWhoamiController implements RequestHandlerInterface
+{
+    use JsonResponseTrait;
+
+    /** Slot prefix used by AuthCredentialStore for per-app state. */
+    private const CREDENTIAL_STATE_PREFIX = 'auth_app_state/';
+
+    public function __construct(
+        private readonly ConfigLoader $configLoader,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $session = $request->getAttribute(HordeSessionMiddleware::ATTRIBUTE_SESSION);
+        if (!$session instanceof HordeSession) {
+            // The middleware always sets this attribute. Missing means
+            // the route is misconfigured. Fail loudly rather than serve
+            // a silent 200 with empty data.
+            return $this->jsonError(
+                'Session middleware did not populate the session attribute.',
+                500,
+                'session_unavailable',
+            );
+        }
+
+        $userId = $this->extractUserId($session);
+        $isAuthenticated = $userId !== null;
+
+        if (!$isAuthenticated && !$this->isPublic()) {
+            return $this->jsonUnauthorized('Authentication required.');
+        }
+
+        // Build a fresh AuthCredentialStore bound to the request's
+        // session. The DI-resolved store is keyed to whatever session
+        // HordeSessionFactory produced at request start, NOT the one
+        // the middleware loaded from the cookie. Constructing locally
+        // is the prototype-correct path.
+        $credentialStore = new AuthCredentialStore($session);
+
+        return $this->jsonResponse([
+            'session_id' => (string) $session->getId(),
+            'authenticated' => $isAuthenticated,
+            'user_id' => $userId,
+            'session_age_seconds' => $this->sessionAgeSeconds($session),
+            'credentials' => $this->collectCredentialStates($session, $credentialStore),
+        ]);
+    }
+
+    /**
+     * Whether anonymous callers may see whoami output.
+     *
+     * Defaults to false (gated). Operators flip to true for diagnostic
+     * smoke testing of the modern session stack.
+     */
+    private function isPublic(): bool
+    {
+        $state = $this->configLoader->load('horde');
+        $value = $state->get('session_whoami.public', false);
+        return (bool) ($value ?? false);
+    }
+
+    /**
+     * Read the authenticated user id from the standard session slot.
+     *
+     * Treats empty string and non-string values as anonymous.
+     */
+    private function extractUserId(HordeSession $session): ?string
+    {
+        $value = $session->getScoped('horde', 'auth/userId');
+        return is_string($value) && $value !== '' ? $value : null;
+    }
+
+    /** Seconds since session begin, or 0 if begin is unknown. */
+    private function sessionAgeSeconds(HordeSession $session): int
+    {
+        $begin = $session->getSessionBegin();
+        if ($begin === null) {
+            return 0;
+        }
+        return max(0, time() - $begin->getTimestamp());
+    }
+
+    /**
+     * Build the per-app credential-state map.
+     *
+     * Walks every key under the `horde` scope that begins with the
+     * `auth_app_state/` prefix and asks `AuthCredentialStore` for the
+     * matching state. Reports only apps with explicit state recorded;
+     * apps with implicit `NeverHad` are omitted.
+     *
+     * TODO: this prototype knowingly couples to the slot prefix that
+     * is `AuthCredentialStore`'s private layout detail. When a real
+     * consumer needs per-app state listing, factor a method out of
+     * this controller into `AuthCredentialStore` and drop the prefix
+     * walk. Tracked in
+     * `horde-development/strategies/modern-session-migration/session-whoami-demo-plan-2026-06-11.md`.
+     *
+     * @return array<string, string>
+     */
+    private function collectCredentialStates(HordeSession $session, AuthCredentialStore $credentialStore): array
+    {
+        $states = [];
+        foreach ($session->keysForApp('horde') as $key) {
+            if (!str_starts_with($key, self::CREDENTIAL_STATE_PREFIX)) {
+                continue;
+            }
+            $app = substr($key, strlen(self::CREDENTIAL_STATE_PREFIX));
+            if ($app === '') {
+                continue;
+            }
+            $states[$app] = $credentialStore->getState($app)->value;
+        }
+        return $states;
+    }
+}

--- a/src/Service/SessionWhoamiControllerFactory.php
+++ b/src/Service/SessionWhoamiControllerFactory.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (LGPL). If you
+ * did not receive this file, see http://www.horde.org/licenses/lgpl21.
+ *
+ * @category  Horde
+ * @copyright 2026 The Horde Project
+ * @license   http://www.horde.org/licenses/lgpl21 LGPL 2.1
+ * @package   Horde
+ */
+
+namespace Horde\Horde\Service;
+
+use Horde\Core\Config\ConfigLoader;
+use Horde\Injector\Injector;
+
+/**
+ * DI factory for {@see SessionWhoamiController}.
+ *
+ * Only `ConfigLoader` is wired up via DI. The controller constructs an
+ * `AuthCredentialStore` per-request bound to the session the modern
+ * middleware loaded onto the request, NOT the DI-resolved one (which
+ * is keyed to whatever `HordeSessionFactory` produced at request start
+ * and is unrelated to the cookie path).
+ */
+class SessionWhoamiControllerFactory
+{
+    public function create(Injector $injector): SessionWhoamiController
+    {
+        return new SessionWhoamiController(
+            $injector->getInstance(ConfigLoader::class),
+        );
+    }
+}

--- a/test/Unit/Service/SessionWhoamiControllerTest.php
+++ b/test/Unit/Service/SessionWhoamiControllerTest.php
@@ -1,0 +1,192 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (LGPL). If you
+ * did not receive this file, see http://www.horde.org/licenses/lgpl21.
+ *
+ * @category  Horde
+ * @copyright 2026 The Horde Project
+ * @license   http://www.horde.org/licenses/lgpl21 LGPL 2.1
+ * @package   Horde
+ */
+
+namespace Horde\Horde\Test\Unit\Service;
+
+use Horde\Core\Auth\HasCredentialsState;
+use Horde\Core\Config\ConfigLoader;
+use Horde\Core\Config\State;
+use Horde\Core\Middleware\HordeSessionMiddleware;
+use Horde\Core\Session\HordeSession;
+use Horde\Horde\Service\SessionWhoamiController;
+use Horde\SessionHandler\SessionId;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Unit tests for {@see SessionWhoamiController}.
+ *
+ * Construction strategy: real `HordeSession` and ConfigLoader stub.
+ * The controller builds its own `AuthCredentialStore` from the
+ * request's session, so tests do not have to wire one. Real
+ * `HordeSession` is cheaper than mocking it: it's a value object
+ * whose constructor takes only a `SessionId` and a data array.
+ */
+#[CoversClass(SessionWhoamiController::class)]
+final class SessionWhoamiControllerTest extends TestCase
+{
+    /** Build a real `HordeSession` carrying the supplied scoped data. */
+    private function makeSession(array $hordeScope = [], int $beginOffset = 0): HordeSession
+    {
+        $data = [];
+        if ($beginOffset !== 0) {
+            $data['_b'] = time() - $beginOffset;
+        }
+        $session = new HordeSession(new SessionId('test-session-id'), $data);
+        foreach ($hordeScope as $key => $value) {
+            $session->setScoped('horde', $key, $value);
+        }
+        return $session;
+    }
+
+    private function makeRequest(?HordeSession $session): ServerRequestInterface
+    {
+        $request = $this->createStub(ServerRequestInterface::class);
+        $request->method('getAttribute')
+            ->willReturnCallback(static function (string $name) use ($session): mixed {
+                return $name === HordeSessionMiddleware::ATTRIBUTE_SESSION ? $session : null;
+            });
+        return $request;
+    }
+
+    /** Build a `ConfigLoader` whose `load('horde')` returns a `State` over the given conf array. */
+    private function makeConfigLoader(array $conf): ConfigLoader
+    {
+        $loader = $this->createStub(ConfigLoader::class);
+        $loader->method('load')->willReturn(new State($conf));
+        return $loader;
+    }
+
+    public function testReturnsJsonForAuthenticatedUser(): void
+    {
+        $session = $this->makeSession(['auth/userId' => 'alice']);
+        $controller = new SessionWhoamiController($this->makeConfigLoader([]));
+
+        $response = $controller->handle($this->makeRequest($session));
+
+        self::assertSame(200, $response->getStatusCode());
+        $body = json_decode((string) $response->getBody(), true, flags: JSON_THROW_ON_ERROR);
+        self::assertTrue($body['authenticated']);
+        self::assertSame('alice', $body['user_id']);
+        self::assertSame('test-session-id', $body['session_id']);
+    }
+
+    public function testRejectsAnonymousByDefault(): void
+    {
+        $session = $this->makeSession();
+        $controller = new SessionWhoamiController($this->makeConfigLoader([]));
+
+        $response = $controller->handle($this->makeRequest($session));
+
+        self::assertSame(401, $response->getStatusCode());
+        $body = json_decode((string) $response->getBody(), true, flags: JSON_THROW_ON_ERROR);
+        self::assertSame('unauthorized', $body['error']);
+    }
+
+    public function testServesAnonymousInPublicMode(): void
+    {
+        $session = $this->makeSession();
+        $controller = new SessionWhoamiController(
+            $this->makeConfigLoader(['session_whoami' => ['public' => true]]),
+        );
+
+        $response = $controller->handle($this->makeRequest($session));
+
+        self::assertSame(200, $response->getStatusCode());
+        $body = json_decode((string) $response->getBody(), true, flags: JSON_THROW_ON_ERROR);
+        self::assertFalse($body['authenticated']);
+        self::assertNull($body['user_id']);
+        self::assertSame([], $body['credentials']);
+    }
+
+    public function testReturnsJsonForAuthenticatedUserPublicMode(): void
+    {
+        $session = $this->makeSession(['auth/userId' => 'alice']);
+        $controller = new SessionWhoamiController(
+            $this->makeConfigLoader(['session_whoami' => ['public' => true]]),
+        );
+
+        $response = $controller->handle($this->makeRequest($session));
+
+        self::assertSame(200, $response->getStatusCode());
+        $body = json_decode((string) $response->getBody(), true, flags: JSON_THROW_ON_ERROR);
+        self::assertTrue($body['authenticated']);
+        self::assertSame('alice', $body['user_id']);
+    }
+
+    public function testReturnsServerErrorIfSessionAttributeMissing(): void
+    {
+        $controller = new SessionWhoamiController($this->makeConfigLoader([]));
+
+        $response = $controller->handle($this->makeRequest(null));
+
+        self::assertSame(500, $response->getStatusCode());
+        $body = json_decode((string) $response->getBody(), true, flags: JSON_THROW_ON_ERROR);
+        self::assertSame('session_unavailable', $body['error']);
+    }
+
+    public function testIncludesCredentialStateMap(): void
+    {
+        $session = $this->makeSession(['auth/userId' => 'alice']);
+        // Seed the state slots directly. The controller's prefix walk
+        // reads the `auth_app_state/` slots and asks the per-request
+        // AuthCredentialStore (built inside handle()) to interpret them.
+        $session->setScoped('horde', 'auth_app_state/imp', HasCredentialsState::Present->value);
+        $session->setScoped('horde', 'auth_app_state/kronolith', HasCredentialsState::Invalidated->value);
+        $controller = new SessionWhoamiController($this->makeConfigLoader([]));
+
+        $response = $controller->handle($this->makeRequest($session));
+
+        self::assertSame(200, $response->getStatusCode());
+        $body = json_decode((string) $response->getBody(), true, flags: JSON_THROW_ON_ERROR);
+        self::assertSame(HasCredentialsState::Present->value, $body['credentials']['imp'] ?? null);
+        self::assertSame(HasCredentialsState::Invalidated->value, $body['credentials']['kronolith'] ?? null);
+    }
+
+    public function testSessionAgeReportsTimeSinceBegin(): void
+    {
+        $session = $this->makeSession(['auth/userId' => 'alice'], beginOffset: 100);
+        $controller = new SessionWhoamiController($this->makeConfigLoader([]));
+
+        $response = $controller->handle($this->makeRequest($session));
+
+        $body = json_decode((string) $response->getBody(), true, flags: JSON_THROW_ON_ERROR);
+        self::assertGreaterThanOrEqual(99, $body['session_age_seconds']);
+        self::assertLessThanOrEqual(101, $body['session_age_seconds']);
+    }
+
+    public function testSessionAgeIsZeroWhenBeginUnknown(): void
+    {
+        $session = $this->makeSession(['auth/userId' => 'alice']);
+        $controller = new SessionWhoamiController($this->makeConfigLoader([]));
+
+        $response = $controller->handle($this->makeRequest($session));
+
+        $body = json_decode((string) $response->getBody(), true, flags: JSON_THROW_ON_ERROR);
+        self::assertSame(0, $body['session_age_seconds']);
+    }
+
+    public function testEmptyUserIdTreatedAsAnonymous(): void
+    {
+        $session = $this->makeSession(['auth/userId' => '']);
+        $controller = new SessionWhoamiController($this->makeConfigLoader([]));
+
+        $response = $controller->handle($this->makeRequest($session));
+
+        self::assertSame(401, $response->getStatusCode());
+    }
+}


### PR DESCRIPTION
Manufactures a small standalone PSR-15 route that exercises the
modern session middleware stack end-to-end. No retrofit of an
existing route. Every existing controller in base/src either depends
on HordeCore middleware (which calls Horde_Registry::appInit and
populates globals) or reaches into globals directly. The whole
point of the demo is to prove the modern stack works without that.

Endpoint contract: GET /api/v1/session/whoami returns JSON with
session id, authenticated flag, user id, session age, and per-app
credential state map. An anonymous caller gets 401 by default.
Setting $conf['session_whoami']['public']=true serves anonymous
callers a populated body. The auth gate moves to the modern
permissions stack once that lands.

Stack: ErrorFilter -> JwtSessionLoader -> HordeSessionMiddleware
-> SessionWhoamiController. No HordeCore. No AuthHordeSession. No
Horde_Registry.

Controller constructs an AuthCredentialStore per request bound to
the session attribute the middleware put on the request. The
DI-resolved AuthCredentialStore is keyed to whatever HordeSession
HordeSessionFactory produced at request start, NOT the one the
middleware loaded from the cookie. Local construction is the
prototype-correct path. Future work refactors per-app state listing
into AuthCredentialStore properly when a real consumer arrives.

Plan: horde-development/strategies/modern-session-migration/
session-whoami-demo-plan-2026-06-11.md
