### PR TITLE
feat: OIDC/OAuth2 authentication integration for Horde base

### DIFF
--- a/config/conf.xml
+++ b/config/conf.xml
@@ -751,6 +751,22 @@ cookie policy. See session configuration options.">$_SERVER['SERVER_NAME'] ?? $_
         </configswitch>
       </configsection>
     </case>
+    <case name="oidc" desc="OpenID Connect (OIDC) / OAuth2 Authentication.
+    Users authenticate via an external identity provider (e.g. Apereo CAS,
+    Keycloak). Requires at least one provider to be configured under
+    Administration > Authentication > OAuth Providers with a Client ID and
+    Client Secret, and token storage to be configured in the OAuth / OIDC
+    Tokens tab.">
+     <configsection name="params">
+     <configstring name="redirect_provider" required="false"
+      desc="Provider ID to redirect to automatically on login. Must match
+      the 'Provider ID' field of an enabled provider configured under
+      Administration &gt; Authentication &gt; OAuth Providers.
+      Leave empty to show the login page with all configured provider
+      buttons. If multiple providers are configured, set this to the ID
+      of the one that should handle automatic login (e.g. 'cas-upjv')." />
+     </configsection>
+    </case>
    </configswitch>
 
    <configsection name="params">
@@ -2599,6 +2615,31 @@ cookie policy. See session configuration options.">$_SERVER['SERVER_NAME'] ?? $_
     </case>
     <case name="Sql" desc="SQL Database (shared across workers/servers)">
      <configsection name="flow_store_params">
+      <configsql switchname="driverconfig" />
+     </configsection>
+    </case>
+   </configswitch>
+
+  </configsection>
+
+ </configtab>
+  <configtab name="oauth" desc="OAuth / OIDC Tokens">
+  <configsection name="oauth">
+   <configheader>OAuth / OIDC Token Storage</configheader>
+   <configdescription>Configure where OAuth2 access and refresh tokens are
+   stored server-side. These tokens are required when Horde authenticates
+   users via OIDC (auth driver = oidc) so that applications such as IMP
+   can connect to IMAP and SMTP servers using XOAUTH2 without storing the
+   user password in the Horde session. Must be set to SQL for any
+   multi-worker or production deployment.</configdescription>
+
+   <configswitch name="token_driver" desc="Token storage backend">null
+    <case name="null" desc="None — tokens are not persisted (testing only,
+    single-process only)">
+    </case>
+    <case name="sql" desc="SQL Database (required for production OIDC
+    deployments and multi-worker setups)">
+     <configsection name="token_params">
       <configsql switchname="driverconfig" />
      </configsection>
     </case>

--- a/config/hooks.php.dist
+++ b/config/hooks.php.dist
@@ -104,6 +104,19 @@
  *                    credentials.
  *   (array) - Replace the credentials with the given value.
  *
+ * smtp pre-authentication. This hook allows
+ * modification of credentials immediately before authentication to the
+ * SMTP server. This gives the chance to modify the username and
+ * have it affect ONLY the IMAP authentication process. I.e., the modified
+ * username is NOT visible to Horde or any application. This is useful e.g.
+ * when the IMAP server requires prepending the user's IP address to the
+ * username for audit purposes.
+ *
+ * @param array $credentials  An array containing authentication credentials
+ *   - userId: (string) The authentication username.
+ *
+ * @return array The possibly modified authentication credentials.
+ *
  * authusername
  * ------------
  * This hook is used to dynamically convert between an authentication username
@@ -1300,6 +1313,44 @@ class Horde_Hooks
 //        ];
 //
 //        return $map[$deviceId] ?? null;
+//    }
+
+    /**
+     * smtp_credentials
+     *
+     * Called by Horde_Core_Factory_Mail when creating the SMTP transport.
+     *
+     * @param string $username Authenticated Horde username
+     * @return array Credentials with 'xoauth2_token' and 'username' keys
+     * @throws Horde_Exception_HookNotSet If XOAUTH2 not applicable
+     */
+//    public function smtp_credentials(string $username): array
+//    {
+//        global $injector;
+//
+//        $tokenService   = $injector->getInstance(\Horde\Core\Service\OAuthTokenService::class);
+//        $providerConfig = $injector->getInstance(\Horde\Core\Service\OAuthProviderConfigRepository::class);
+//
+//        $row = \Horde\Core\Service\OidcHookHelper::findProviderForUser(
+//            $username, $tokenService, $providerConfig
+//        );
+//        if ($row === null) {
+//            throw new Horde_Exception_HookNotSet();
+//        }
+//
+//        $accessToken = \Horde\Core\Service\OidcHookHelper::getValidAccessToken(
+//            $username, $row, $tokenService, $injector
+//        );
+//        if ($accessToken === null) {
+//            throw new Horde_Exception_HookNotSet();
+//        }
+//
+//        $xoauth2User = \Horde\Core\Service\OidcHookHelper::xoauth2Username($username, $row);
+//
+//        return [
+//            'xoauth2_token' => new Horde_Smtp_Password_Xoauth2($xoauth2User, $accessToken),
+//            'username'      => $xoauth2User,
+//        ];
 //    }
 
 

--- a/config/routes.php
+++ b/config/routes.php
@@ -46,7 +46,7 @@ $mapper->buildRoute(uri: '/auth/oauth/login/:providerId', name: 'OAuthLogin')
     ->withController(Auth\OAuthLoginController::class)
     ->withDefaults(['HordeAuthType' => 'NONE'])
     ->withMiddleware([AuthHordeSession::class])
-    ->withMethods(['POST'])
+    ->withMethods(['POST', 'GET'])
     ->add();
 
 // Responsive UI Routes - Phase 1: Portal
@@ -582,4 +582,16 @@ $mapper->buildRoute(uri: '/api/v1/session/whoami', name: 'SessionWhoami')
         HordeSessionMiddleware::class,
     ])
     ->withMethods(['GET'])
+    ->add();
+
+// OIDC Back-Channel Logout (RFC 9470)
+// Receives a signed logout_token JWT from the identity provider.
+// POST only, no Horde session required (the IdP has no session with us).
+// Always returns 200 to prevent provider retries.
+// Configure in your IdP (Apereo CAS): logoutType=BACK_CHANNEL, logoutUrl=<this URL>
+$mapper->buildRoute(uri: '/auth/oidc/backchannel-logout', name: 'OidcBackchannelLogout')
+    ->withController(\Horde\Core\Auth\OidcBackchannelLogoutController::class)
+    ->withDefaults(['HordeAuthType' => 'NONE'])
+    ->withMiddleware([HordeCore::class, ErrorFilter::class])
+    ->withMethods(['POST'])
     ->add();

--- a/login.php
+++ b/login.php
@@ -125,6 +125,7 @@ if (!$is_auth && !$prefs->isLocked('language') && $vars->new_lang) {
 }
 
 if ($logout_reason) {
+    $postLogoutData = ['redirect' => null];
     if ($is_auth) {
         try {
             $tokenService = $injector->getInstance(Token::class);
@@ -144,35 +145,27 @@ if ($logout_reason) {
             require HORDE_BASE . '/index.php';
             exit;
         }
-        $is_auth = null;
 
-        $logger->notice(sprintf(
-            'User %s logged out of Horde (%s)%s',
-            $registry->getAuth(),
-            $_SERVER['REMOTE_ADDR'],
-            empty($_SERVER['HTTP_X_FORWARDED_FOR']) ? '' : ' (forwarded for [' . $_SERVER['HTTP_X_FORWARDED_FOR'] . '])'
+        $loginService = $injector->getInstance(\Horde\Horde\Service\LoginService::class);
+        $postLogoutData = $loginService->performLogout(new \Horde\Horde\ValueObject\LogoutRequest(
+            csrfToken: null, // already verified above
+            reason: $logout_reason,
+            remoteAddr: $_SERVER['REMOTE_ADDR'],
+            forwardedFor: $_SERVER['HTTP_X_FORWARDED_FOR'] ?? null,
         ));
+        $is_auth = null;
+    } else {
+        $registry->clearAuth();
+        $session->setup();
     }
 
-    $registry->clearAuth();
-
-    /* Reset notification handler now, since it may still be using a status
-     * handler that is no longer valid. */
-    $notification->detach('status');
-    $notification->attach('status');
-
-    /* Redirect the user on logout if redirection is enabled and this is an
-     * an intended logout. */
-    if (($logout_reason == Horde_Auth::REASON_LOGOUT)
-        && !empty($conf['auth']['redirect_on_logout'])) {
-        $logout_url = new Horde_Url($conf['auth']['redirect_on_logout'], true);
+    if (!empty($postLogoutData['redirect'])) {
+        $logout_url = new Horde_Url($postLogoutData['redirect'], true);
         if (!isset($_COOKIE[session_name()])) {
             $logout_url->add(session_name(), session_id());
         }
         _addAnchor($logout_url, 'url', $vars, $url_anchor)->redirect();
     }
-
-    $session->setup();
 
     /* Explicitly set language in un-authenticated session. */
     $registry->setLanguage($GLOBALS['language']);

--- a/login.php
+++ b/login.php
@@ -375,6 +375,22 @@ if ($is_auth) {
     }
 }
 
+// OIDC auth driver: auto-redirect to the configured identity provider.
+// When auth.driver = oidc and auth.params.redirect_provider is set,
+// build alternate_login automatically so login.php redirects to the
+// provider without showing the username/password form.
+if (empty($conf['auth']['alternate_login'])
+    && strcasecmp($conf['auth']['driver'] ?? '', 'oidc') === 0
+    && !empty($conf['auth']['params']['redirect_provider'])
+    && (!($logout_reason === Horde_Auth::REASON_BADLOGIN
+        || $logout_reason === Horde_Auth::REASON_FAILED
+        || $logout_reason === Horde_Auth::REASON_LOCKED))) {
+    $conf['auth']['alternate_login'] =
+        rtrim($registry->get('webroot', 'horde'), '/')
+        . '/auth/oauth/login/'
+        . rawurlencode($conf['auth']['params']['redirect_provider']);
+}
+
 /* Redirect the user if an alternate login page has been specified. */
 if (!empty($conf['auth']['alternate_login'])) {
     $url = new Horde_Url($conf['auth']['alternate_login'], true);

--- a/migration/3_horde_oauth_providers_oidc_fields.php
+++ b/migration/3_horde_oauth_providers_oidc_fields.php
@@ -1,0 +1,49 @@
+<?php
+// migration/3_horde_oauth_providers_oidc_fields.php
+
+class HordeOauthProvidersOidcFields extends Horde_Db_Migration_Base
+{
+    public function up()
+    {
+        $cols = array_column(
+            $this->columns('horde_oauth_providers'),
+            null,
+            'name'
+        );
+
+        if (!isset($cols['logout_type'])) {
+            $this->addColumn('horde_oauth_providers', 'logout_type',
+                'string', ['limit' => 20, 'default' => 'local']);
+        }
+        if (!isset($cols['end_session_endpoint'])) {
+            $this->addColumn('horde_oauth_providers', 'end_session_endpoint',
+                'string', ['limit' => 1024]);
+        }
+        if (!isset($cols['post_logout_redirect_uri'])) {
+            $this->addColumn('horde_oauth_providers', 'post_logout_redirect_uri',
+                'string', ['limit' => 1024]);
+        }
+        if (!isset($cols['backchannel_username_claim'])) {
+            $this->addColumn('horde_oauth_providers', 'backchannel_username_claim',
+                'string', ['limit' => 64, 'default' => 'sub']);
+        }
+        if (!isset($cols['xoauth2_use_email'])) {
+            $this->addColumn('horde_oauth_providers', 'xoauth2_use_email',
+                'integer', ['default' => 0]);
+        }
+        if (!isset($cols['xoauth2_domain'])) {
+            $this->addColumn('horde_oauth_providers', 'xoauth2_domain',
+                'string', ['limit' => 255]);
+        }
+    }
+
+    public function down()
+    {
+        foreach ([
+            'logout_type', 'end_session_endpoint', 'post_logout_redirect_uri',
+            'backchannel_username_claim', 'xoauth2_use_email', 'xoauth2_domain',
+        ] as $col) {
+            $this->removeColumn('horde_oauth_providers', $col);
+        }
+    }
+}

--- a/src/Admin/OAuthProviderController.php
+++ b/src/Admin/OAuthProviderController.php
@@ -279,6 +279,8 @@ class OAuthProviderController implements RequestHandlerInterface
             'revocation_endpoint', 'introspection_endpoint',
             'default_scopes',
             'app_identifier', 'installation_id',
+            'logout_type', 'end_session_endpoint', 'post_logout_redirect_uri',
+            'backchannel_username_claim', 'xoauth2_use_email', 'xoauth2_domain',
         ];
 
         $data = [];
@@ -286,6 +288,10 @@ class OAuthProviderController implements RequestHandlerInterface
             if (array_key_exists($field, $body)) {
                 $data[$field] = $body[$field];
             }
+        }
+
+        if (isset($data['xoauth2_use_email'])) {
+            $data['xoauth2_use_email'] = (int) ($data['xoauth2_use_email'] ?? 0);
         }
 
         if ($data['enabled'] ?? null !== null) {

--- a/src/Auth/OAuthLoginController.php
+++ b/src/Auth/OAuthLoginController.php
@@ -68,8 +68,10 @@ class OAuthLoginController implements RequestHandlerInterface
             return $this->redirect($loginUrl . '?error=failed');
         }
 
-        $body = $request->getParsedBody() ?? [];
-        $redirectUrl = is_string($body['url'] ?? null) ? $body['url'] : '';
+        $params = $request->getMethod() === 'GET'
+            ? $request->getQueryParams()
+            : ($request->getParsedBody() ?? []);
+        $redirectUrl = is_string($params['url'] ?? null) ? $params['url'] : '';
 
         $verifier = PkceGenerator::generateVerifier();
         $challenge = PkceGenerator::computeChallenge($verifier);

--- a/src/Factory/LoginServiceFactory.php
+++ b/src/Factory/LoginServiceFactory.php
@@ -18,6 +18,7 @@ namespace Horde\Horde\Factory;
 use Exception;
 use Horde\Core\Config\ConfigLoader;
 use Horde\Core\Service\OAuthProviderConfigRepository;
+use Horde\Core\Service\OidcPreLogoutHandler;
 use Horde\Core\Session\HordeSession;
 use Horde\Core\Session\SessionConfig;
 use Horde\Core\Session\SessionLifecycle;
@@ -68,6 +69,18 @@ class LoginServiceFactory
         // ConfigLoader is unavailable (test fixtures, partial DI setups).
         $conf = $this->resolveConf($injector);
 
+        // Collect pre-logout handlers. Handlers are registered conditionally
+        // based on the configured auth driver. Additional handlers can be
+        // added here as new auth drivers are introduced.
+        $preLogoutHandlers = [];
+        if (strcasecmp($conf['auth']['driver'] ?? '', 'oidc') === 0) {
+            try {
+                $preLogoutHandlers[] = $injector->getInstance(OidcPreLogoutHandler::class);
+            } catch (Exception $e) {
+                $logger->warning('Could not resolve OidcPreLogoutHandler: ' . $e->getMessage());
+            }
+        }
+
         return new LoginService(
             $registry,
             $logger,
@@ -82,6 +95,7 @@ class LoginServiceFactory
             $sessionConfig,
             $notification,
             $conf,
+            $preLogoutHandlers,
         );
     }
 

--- a/src/Factory/OAuthTokenRepositoryFactory.php
+++ b/src/Factory/OAuthTokenRepositoryFactory.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (LGPL). If you
+ * did not receive this file, see http://www.horde.org/licenses/lgpl21.
+ *
+ * @category Horde
+ * @package  Horde
+ * @author   Ralf Lang <ralf.lang@ralf-lang.de>
+ * @license  http://www.horde.org/licenses/lgpl21 LGPL 2.1
+ */
+
+namespace Horde\Horde\Factory;
+
+use Horde\Core\Service\OAuthTokenRepository;
+use Horde\Db\Adapter;
+use Horde\Horde\Service\SqlOAuthTokenRepository;
+use Horde\Injector\Injector;
+use Horde\Secret\SecretManager;
+
+/**
+ * Factory for OAuthTokenRepository.
+ *
+ * Returns SqlOAuthTokenRepository backed by the Horde DB adapter.
+ */
+class OAuthTokenRepositoryFactory
+{
+    public function create(Injector $injector): OAuthTokenRepository
+    {
+        return new SqlOAuthTokenRepository(
+            db: $injector->getInstance(Adapter::class),
+            secret: $injector->getInstance(SecretManager::class),
+        );
+    }
+}

--- a/src/Service/LoginService.php
+++ b/src/Service/LoginService.php
@@ -26,6 +26,7 @@ use Horde_Url;
 use Horde\Core\Assets\ResponsiveAssets;
 use Horde\Core\Config\RegistryState;
 use Horde\Core\Service\OAuthProviderConfigRepository;
+use Horde\Core\Service\PreLogoutHandlerInterface;
 use Horde\Core\Session\HordeSession;
 use Horde\Core\Session\SessionConfig;
 use Horde\Core\Session\SessionLifecycle;
@@ -71,6 +72,7 @@ class LoginService
         private readonly SessionConfig $sessionConfig,
         private readonly Horde_Notification_Handler $notification,
         private readonly array $conf,
+        private readonly array $preLogoutHandlers = [],
     ) {}
 
     /**
@@ -440,13 +442,6 @@ class LoginService
         // Reset notification handler (old handler may reference invalid state)
         $this->notification->detach('status');
         $this->notification->attach('status');
-
-        // Check redirect_on_logout config
-        if ($request->reason === Horde_Auth::REASON_LOGOUT
-            && !empty($this->conf['auth']['redirect_on_logout'])) {
-            $logoutUrl = $this->conf['auth']['redirect_on_logout'];
-            return ['redirect' => $logoutUrl, 'reason' => $request->reason];
-        }
 
         // Setup fresh anonymous session via the modern lifecycle.
         // SessionLifecycle::setup() is idempotent and replaces the

--- a/src/Service/LoginService.php
+++ b/src/Service/LoginService.php
@@ -416,6 +416,24 @@ class LoginService
             );
         }
 
+        // Run pre-logout handlers before the session is destroyed.
+        // A failing handler must never prevent the logout from completing.
+        $postLogoutRedirect = null;
+        if ($currentUser) {
+            foreach ($this->preLogoutHandlers as $handler) {
+                try {
+                    $data = $handler->onBeforeLogout($currentUser, $request->reason);
+                    if (!empty($data['redirect']) && $postLogoutRedirect === null) {
+                        $postLogoutRedirect = $data['redirect'];
+                    }
+                } catch (Throwable $e) {
+                    $this->logger->warning(
+                        'PreLogoutHandler ' . $handler::class . ' failed: ' . $e->getMessage()
+                    );
+                }
+            }
+        }
+
         // Clear authentication
         $this->registry->clearAuth();
 
@@ -451,6 +469,17 @@ class LoginService
             $prefs->retrieve();
         } catch (Exception $e) {
             // Ignore - theme will use system default
+        }
+
+        // Handler redirect takes priority over redirect_on_logout config
+        if ($postLogoutRedirect === null
+            && $request->reason === Horde_Auth::REASON_LOGOUT
+            && !empty($this->conf['auth']['redirect_on_logout'])) {
+            $postLogoutRedirect = $this->conf['auth']['redirect_on_logout'];
+        }
+
+        if ($postLogoutRedirect !== null) {
+            return ['redirect' => $postLogoutRedirect, 'reason' => $request->reason];
         }
 
         // Default redirect to login page

--- a/src/Settings/OAuthAccountController.php
+++ b/src/Settings/OAuthAccountController.php
@@ -274,6 +274,12 @@ class OAuthAccountController implements RequestHandlerInterface
             $email = $userinfo['email'] ?? null;
             $displayName = $userinfo['name'] ?? $userinfo['display_name'] ?? $userinfo['login'] ?? null;
 
+            // Resolve a local Horde username from the userinfo claims.
+            // Priority: preferred_username → uid → login → left part of email.
+            // This ensures a human-readable Horde username instead of the
+            // opaque identity UUID, regardless of whether a local link exists.
+            $preferredUsername = $this->resolveLocalUsername($userinfo);
+
             if ($externalId === '') {
                 return $this->redirect($loginUrl . '?error=failed');
             }
@@ -296,7 +302,19 @@ class OAuthAccountController implements RequestHandlerInterface
                 }
             }
 
+            // No local link yet: create one from the preferred username so that
+            // subsequent logins resolve to a human-readable Horde username
+            // instead of the identity UUID.
+            if ($localUsername === null && $preferredUsername !== null) {
+                $this->identityLinkService->coupleLocalUser($identity->id, $preferredUsername);
+                $localUsername = $preferredUsername;
+            }
+
+            // Store tokens so IMP/Ingo hooks can retrieve them via OAuthTokenService.
+            // handleLoginCallback does not link an account but still needs tokens
+            // available for XOAUTH2 authentication in mail clients.
             $authId = $localUsername ?? $identity->id;
+            $this->tokenService->store($authId, $providerId, $tokenSet);
             $this->registry->setAuth($authId, []);
 
             if ($this->identityService->getAll($authId) === []) {
@@ -307,11 +325,17 @@ class OAuthAccountController implements RequestHandlerInterface
                 ]);
             }
 
+            // Filter login.php as redirect destination — it loops back to the portal
+            if ($redirectUrl !== '' && str_contains($redirectUrl, '/login.php')) {
+                $redirectUrl = '';
+            }
+
             if ($redirectUrl !== '') {
                 return $this->redirect($redirectUrl);
             }
 
-            return $this->redirect((string) $this->registry->getServiceLink('portal'));
+            return $this->redirect(rtrim($this->registry->get('webroot', 'horde'), '/') . '/index.php');
+
         } catch (Throwable $e) {
             error_log('OAuthLoginCallback failed: ' . $e->getMessage() . ' in ' . $e->getFile() . ':' . $e->getLine());
             return $this->redirect($loginUrl . '?error=failed');
@@ -401,7 +425,10 @@ class OAuthAccountController implements RequestHandlerInterface
         }
 
         if ($flowData->redirectUrl !== '') {
-            return $this->redirect($flowData->redirectUrl);
+            if (str_contains($flowData->redirectUrl, '/login.php')) {
+                $initialPage = $this->registry->getInitialPage('horde');
+                return $this->redirect($initialPage ?? (string) $this->registry->getServiceLink('portal'));
+            }
         }
 
         return $this->redirect($baseUrl . '/');
@@ -487,5 +514,40 @@ class OAuthAccountController implements RequestHandlerInterface
     private function getBaseUrl(): string
     {
         return rtrim($this->registry->get('webroot', 'horde'), '/') . '/settings/oauth';
+    }
+
+
+    /**
+     * Resolve a local Horde username from OIDC userinfo claims.
+     *
+     * Priority:
+     *   1. preferred_username  (standard OIDC claim, used by CAS, Keycloak…)
+     *   2. uid                 (LDAP-style claim, common in university IdPs)
+     *   3. login               (GitHub, GitLab)
+     *   4. left part of email  (last resort, strips domain)
+     *
+     * Returns null if none of the above are available, in which case the
+     * caller falls back to the identity UUID.
+     */
+    private function resolveLocalUsername(array $userinfo): ?string
+    {
+        foreach (['preferred_username', 'uid', 'login', 'sub', 'id'] as $claim) {
+            $value = trim((string) ($userinfo[$claim] ?? ''));
+            if ($value !== '') {
+                // Strip domain suffix if present (e.g. "jdoe@example.com" → "jdoe")
+                return strstr($value, '@', true) ?: $value;
+            }
+        }
+
+        // Last resort: left part of email
+        $email = trim((string) ($userinfo['email'] ?? ''));
+        if ($email !== '') {
+            $local = strstr($email, '@', true);
+            if ($local !== false && $local !== '') {
+                return $local;
+            }
+        }
+
+        return null;
     }
 }

--- a/templates/admin/oauthprovider/edit-oauth2.html.php
+++ b/templates/admin/oauthprovider/edit-oauth2.html.php
@@ -126,6 +126,54 @@
         <span class="settings-form-help"><?php echo _("This is computed automatically. Copy this value into your provider's console.") ?></span>
       </div>
 
+<?php if ($this->provider['type'] === 'oidc'): ?>
+      <h3 class="settings-section-title"><?php echo _("Logout / Single Log-Out") ?></h3>
+
+      <div class="settings-form-row">
+        <label class="settings-form-label" for="logout_type"><?php echo _("Logout Strategy") ?></label>
+        <select id="logout_type" name="logout_type" class="settings-form-control">
+          <?php foreach (['local' => _("Local only"), 'slo' => _("SLO redirect"), 'revoke_and_slo' => _("Revoke tokens + SLO redirect")] as $val => $label): ?>
+          <option value="<?php echo $val ?>"<?php if (($this->provider['logout_type'] ?? 'local') === $val): ?> selected<?php endif ?>><?php echo $label ?></option>
+          <?php endforeach ?>
+        </select>
+        <span class="settings-form-help"><?php echo _("Local: clear tokens locally only. SLO: also redirect to provider end_session_endpoint. Revoke: also call revocation endpoint before redirect.") ?></span>
+      </div>
+
+      <div class="settings-form-row">
+        <label class="settings-form-label" for="end_session_endpoint"><?php echo _("End Session Endpoint") ?></label>
+        <input type="url" id="end_session_endpoint" name="end_session_endpoint" class="settings-form-control" value="<?php echo $this->h($this->provider['end_session_endpoint'] ?? '') ?>" />
+        <span class="settings-form-help"><?php echo _("Leave empty to use auto-discovery. Required for SLO strategies.") ?></span>
+      </div>
+
+      <div class="settings-form-row">
+        <label class="settings-form-label" for="post_logout_redirect_uri"><?php echo _("Post-Logout Redirect URI") ?></label>
+        <input type="url" id="post_logout_redirect_uri" name="post_logout_redirect_uri" class="settings-form-control" value="<?php echo $this->h($this->provider['post_logout_redirect_uri'] ?? '') ?>" />
+        <span class="settings-form-help"><?php echo _("Where the provider should redirect after SLO. Defaults to Horde portal if empty.") ?></span>
+      </div>
+
+      <div class="settings-form-row">
+        <label class="settings-form-label" for="backchannel_username_claim"><?php echo _("Back-Channel Username Claim") ?></label>
+        <input type="text" id="backchannel_username_claim" name="backchannel_username_claim" class="settings-form-control" value="<?php echo $this->h($this->provider['backchannel_username_claim'] ?? 'sub') ?>" placeholder="sub" />
+        <span class="settings-form-help"><?php echo _("JWT claim used to identify the user in back-channel logout tokens. Usually 'sub'.") ?></span>
+      </div>
+
+      <h3 class="settings-section-title"><?php echo _("XOAUTH2 / Mail Authentication") ?></h3>
+
+      <div class="settings-form-row">
+        <label class="settings-form-label" for="xoauth2_use_email"><?php echo _("Use email address as XOAUTH2 username") ?></label>
+        <select id="xoauth2_use_email" name="xoauth2_use_email" class="settings-form-control">
+          <option value="0"<?php if (empty($this->provider['xoauth2_use_email'])): ?> selected<?php endif ?>><?php echo _("No — use Horde username as-is") ?></option>
+          <option value="1"<?php if (!empty($this->provider['xoauth2_use_email'])): ?> selected<?php endif ?>><?php echo _("Yes — append domain below") ?></option>
+        </select>
+      </div>
+
+      <div class="settings-form-row">
+        <label class="settings-form-label" for="xoauth2_domain"><?php echo _("XOAUTH2 Domain") ?></label>
+        <input type="text" id="xoauth2_domain" name="xoauth2_domain" class="settings-form-control" value="<?php echo $this->h($this->provider['xoauth2_domain'] ?? '') ?>" placeholder="example.com" />
+        <span class="settings-form-help"><?php echo _("Domain appended to the username for XOAUTH2 (e.g. 'jdoe' → 'jdoe@example.com'). Only used if the option above is enabled.") ?></span>
+      </div>
+      <?php endif ?>
+
       <h3 class="settings-section-title"><?php echo _("Appearance") ?></h3>
 
       <div class="settings-form-row">


### PR DESCRIPTION
    Wires the OIDC auth driver (horde/Core) into the Horde base application:
    
    - OAuthLoginController: accept GET in addition to POST to support
      automatic redirect from login.php to the IdP.
    
    - login.php: auto-redirect to the configured OIDC provider when
      auth.driver = oidc and auth.params.redirect_provider is set.
      Redirects on all logout reasons except explicit auth failures
      (REASON_BADLOGIN, REASON_FAILED, REASON_LOCKED).
    
    - LoginServiceFactory: register OidcPreLogoutHandler as a pre-logout
      handler when the auth driver is oidc.
    
    - LoginService::performLogout(): aggregate redirect URLs from
      pre-logout handlers; handler redirect takes priority over
      redirect_on_logout config.
    
    - OAuthAccountController: resolve a human-readable Horde username from
      OIDC userinfo claims (preferred_username, uid, login, email);
      store tokens for XOAUTH2 hooks; filter login.php as post-login
      redirect destination.
    
    - OAuthTokenRepositoryFactory: SQL-backed token repository.
    
    - Admin UI: OIDC-specific provider fields (logout strategy, SLO
      endpoints, XOAUTH2 domain).
    
    - conf.xml: OIDC auth driver configuration and OAuth/OIDC token
      storage tab.
    
    - Migration 3: add OIDC-specific columns to horde_oauth_providers.
    
    - hooks.php.dist: smtp_credentials and backchannel logout route.
    
    Depends on:
    - horde/Core: OIDC integration (PR #160)
    - horde/base refactor/login-logout-delegate-to-service (PR #109)
