### PR TITLE
Expose sidebar width as CSS custom property and enable global resize

### DIFF
--- a/js/sidebar.js
+++ b/js/sidebar.js
@@ -53,49 +53,145 @@ var HordeSidebar = {
         Prototype.emptyFunction();
     },
 
+    /* Safe read of the stored width (localStorage may throw in private mode). */
+    readStoredWidth: function()
+    {
+        try {
+            var n = parseInt(localStorage.getItem('horde_sidebar_width'), 10);
+            return Number.isFinite(n) ? n : null;
+        } catch (e) {
+            return null;
+        }
+    },
+
+    /* Safe write of the width to localStorage. */
+    storeWidth: function(w)
+    {
+        try {
+            localStorage.setItem('horde_sidebar_width', w);
+        } catch (e) {}
+    },
+
+    /* Clamp a width between the min/max bounds exposed as CSS custom properties. */
+    clampWidth: function(w, cs)
+    {
+        var min = parseInt(cs.getPropertyValue('--horde-sidebar-min-width'), 10) || 250;
+        var max = parseInt(cs.getPropertyValue('--horde-sidebar-max-width'), 10) || 500;
+        return Math.min(Math.max(w, min), max);
+    },
+
     onDomLoad: function()
     {
         this.refreshEvents();
 
+        var self = this;
+        var root = document.documentElement;
+        var cs = getComputedStyle(root);
+
         var s = $('horde-sidebar');
         if (s) {
-            var saved = localStorage.getItem('horde_sidebar_width');
-            var w = saved
-                ? parseInt(saved)
-                : (s.offsetWidth || parseInt(s.style.width) || 250);
-            document.documentElement.style.setProperty('--horde-sidebar-width', w + 'px');
+            var stored = this.readStoredWidth();
+            var w = (stored !== null)
+                ? stored
+                : (s.offsetWidth || parseInt(s.style.width, 10) || 250);
+            if (!Number.isFinite(w)) {
+                w = 250;
+            }
+            w = this.clampWidth(w, cs);
+            root.style.setProperty('--horde-sidebar-width', w + 'px');
         }
 
-        /* Drag-resize sidebar globale */
+        /* Drag-resize global de la sidebar */
         var handle = document.getElementById('horde-slideleftcursor');
         if (!handle) return;
 
+        /* ARIA semantics: the handle acts as a resizable separator. */
+        var min = parseInt(cs.getPropertyValue('--horde-sidebar-min-width'), 10) || 250;
+        var max = parseInt(cs.getPropertyValue('--horde-sidebar-max-width'), 10) || 500;
+        handle.setAttribute('role', 'separator');
+        handle.setAttribute('aria-orientation', 'vertical');
+        handle.setAttribute('aria-label', 'Resize sidebar');
+        handle.setAttribute('aria-valuemin', min);
+        handle.setAttribute('aria-valuemax', max);
+        if (!handle.hasAttribute('tabindex')) {
+            handle.setAttribute('tabindex', '0');
+        }
+
+        var applyWidth = function(w) {
+            w = self.clampWidth(w, cs);
+            root.style.setProperty('--horde-sidebar-width', w + 'px');
+            handle.setAttribute('aria-valuenow', w);
+            return w;
+        };
+
+        /* Mouse drag resize.
+         * Kept as a plain mousedown (not Pointer Events) so it coexists with
+         * application-level handlers bound to the same splitbar — e.g. IMP's
+         * Scriptaculous Drag on #horde-slideleft, which relies on the native
+         * mouse event sequence. */
         handle.addEventListener('mousedown', function(e) {
             e.preventDefault();
-            var root = document.documentElement;
-            var cs = getComputedStyle(root);
             var startX = e.clientX;
-            var startW = parseInt(cs.getPropertyValue('--horde-sidebar-width')) || 250;
-            var getMin = function() { return parseInt(cs.getPropertyValue('--horde-sidebar-min-width')) || 250; };
-            var getMax = function() { return parseInt(cs.getPropertyValue('--horde-sidebar-max-width')) || 500; };
+            var startW = parseInt(cs.getPropertyValue('--horde-sidebar-width'), 10) || 250;
 
+            var prevCursor = document.body.style.cursor;
+            var prevSelect = document.body.style.userSelect;
             document.body.style.cursor = 'col-resize';
             document.body.style.userSelect = 'none';
 
-            function onMove(e) {
-                var newW = Math.min(Math.max(startW + (e.clientX - startX), getMin()), getMax());
-                root.style.setProperty('--horde-sidebar-width', newW + 'px');
+            function onMove(ev) {
+                applyWidth(startW + (ev.clientX - startX));
             }
             function onUp() {
-                document.body.style.cursor = '';
-                document.body.style.userSelect = '';
-                localStorage.setItem('horde_sidebar_width',
-                    parseInt(getComputedStyle(root).getPropertyValue('--horde-sidebar-width')));
+                document.body.style.cursor = prevCursor;
+                document.body.style.userSelect = prevSelect;
+                self.storeWidth(parseInt(cs.getPropertyValue('--horde-sidebar-width'), 10));
                 document.removeEventListener('mousemove', onMove);
                 document.removeEventListener('mouseup', onUp);
             }
             document.addEventListener('mousemove', onMove);
             document.addEventListener('mouseup', onUp);
+        });
+
+        /* Touch drag resize (separate path so the mouse handling above — and
+         * any app handler relying on mouse events — stays untouched). */
+        handle.addEventListener('touchstart', function(e) {
+            if (!e.touches || e.touches.length !== 1) {
+                return;
+            }
+            var startX = e.touches[0].clientX;
+            var startW = parseInt(cs.getPropertyValue('--horde-sidebar-width'), 10) || 250;
+
+            function onMove(ev) {
+                if (!ev.touches || ev.touches.length !== 1) {
+                    return;
+                }
+                /* Prevent scrolling only while actively resizing. */
+                ev.preventDefault();
+                applyWidth(startW + (ev.touches[0].clientX - startX));
+            }
+            function onEnd() {
+                self.storeWidth(parseInt(cs.getPropertyValue('--horde-sidebar-width'), 10));
+                document.removeEventListener('touchmove', onMove);
+                document.removeEventListener('touchend', onEnd);
+                document.removeEventListener('touchcancel', onEnd);
+            }
+            document.addEventListener('touchmove', onMove, { passive: false });
+            document.addEventListener('touchend', onEnd);
+            document.addEventListener('touchcancel', onEnd);
+        }, { passive: true });
+
+        /* Keyboard operability: left/right arrows adjust the width. */
+        handle.addEventListener('keydown', function(e) {
+            var step = e.shiftKey ? 32 : 8;
+            var cur = parseInt(cs.getPropertyValue('--horde-sidebar-width'), 10) || 250;
+            if (e.key === 'ArrowLeft') {
+                e.preventDefault();
+                self.storeWidth(applyWidth(cur - step));
+            } else if (e.key === 'ArrowRight') {
+                e.preventDefault();
+                self.storeWidth(applyWidth(cur + step));
+            }
         });
     }
 };

--- a/js/sidebar.js
+++ b/js/sidebar.js
@@ -56,6 +56,47 @@ var HordeSidebar = {
     onDomLoad: function()
     {
         this.refreshEvents();
+
+        var s = $('horde-sidebar');
+        if (s) {
+            var saved = localStorage.getItem('horde_sidebar_width');
+            var w = saved
+                ? parseInt(saved)
+                : (s.offsetWidth || parseInt(s.style.width) || 250);
+            document.documentElement.style.setProperty('--horde-sidebar-width', w + 'px');
+        }
+
+        /* Drag-resize sidebar globale */
+        var handle = document.getElementById('horde-slideleftcursor');
+        if (!handle) return;
+
+        handle.addEventListener('mousedown', function(e) {
+            e.preventDefault();
+            var root = document.documentElement;
+            var cs = getComputedStyle(root);
+            var startX = e.clientX;
+            var startW = parseInt(cs.getPropertyValue('--horde-sidebar-width')) || 250;
+            var getMin = function() { return parseInt(cs.getPropertyValue('--horde-sidebar-min-width')) || 250; };
+            var getMax = function() { return parseInt(cs.getPropertyValue('--horde-sidebar-max-width')) || 500; };
+
+            document.body.style.cursor = 'col-resize';
+            document.body.style.userSelect = 'none';
+
+            function onMove(e) {
+                var newW = Math.min(Math.max(startW + (e.clientX - startX), getMin()), getMax());
+                root.style.setProperty('--horde-sidebar-width', newW + 'px');
+            }
+            function onUp() {
+                document.body.style.cursor = '';
+                document.body.style.userSelect = '';
+                localStorage.setItem('horde_sidebar_width',
+                    parseInt(getComputedStyle(root).getPropertyValue('--horde-sidebar-width')));
+                document.removeEventListener('mousemove', onMove);
+                document.removeEventListener('mouseup', onUp);
+            }
+            document.addEventListener('mousemove', onMove);
+            document.addEventListener('mouseup', onUp);
+        });
     }
 };
 


### PR DESCRIPTION
Horde computes the sidebar width in JavaScript and applies it as an inline style, which prevents themes from overriding it in pure CSS. This exposes the width as a CSS custom property (--horde-sidebar-width) on <html> so themes can consume it directly.

It also adds a global drag-to-resize on the existing #horde-slideleftcursor handle — previously only IMP could resize the sidebar. The width is clamped between --horde-sidebar-min-width / --horde-sidebar-max-width and persisted in localStorage.

No existing behaviour is removed: the custom property is inert until a theme consumes it, so the default theme is unaffected.

cc @jcdelepine