### PR TITLE
feat(horde): add account-only remote wipe UI/actions with 16.1 gating

### DIFF
--- a/admin/activesync.php
+++ b/admin/activesync.php
@@ -62,6 +62,16 @@ if ($state) {
                 $GLOBALS['notification']->push(_("A device wipe has been requested. Device will be wiped on next syncronization attempt."), 'horde.success');
                 break;
 
+            case 'accountwipe':
+                $device = $state->loadDeviceInfo($deviceID);
+                if (!Horde_ActiveSync::deviceSupportsAccountOnlyWipe($device->version ?? null)) {
+                    $GLOBALS['notification']->push(_("Account-only wipe is only available for devices that support EAS 16.1 or newer."), 'horde.error');
+                    break;
+                }
+                $state->setDeviceRWStatus($deviceID, Horde_ActiveSync::RWSTATUS_ACCOUNTONLY_PENDING);
+                $GLOBALS['notification']->push(_("An account-only wipe has been requested. The account will be removed on next synchronization attempt."), 'horde.success');
+                break;
+
             case 'cancelwipe':
                 $state->setDeviceRWStatus($deviceID, Horde_ActiveSync::RWSTATUS_OK);
                 $GLOBALS['notification']->push(_("Device wipe successfully canceled."), 'horde.success');

--- a/config/conf.xml
+++ b/config/conf.xml
@@ -2278,7 +2278,7 @@ cookie policy. See session configuration options.">$_SERVER['SERVER_NAME'] ?? $_
       </configswitch>
       <configenum name="version" desc="What is the highest version of EAS that
       Horde should support? All versions are backwards compatible so selecting
-      a higher version also includes support for the lower versions as well.">16.0
+      a higher version also includes support for the lower versions as well. 16.1 is feature complete but added late befor release, thus classified as experimental.">16.0
       <values>
        <value desc="Exchange 2003 (EAS 2.5)">2.5</value>
        <value desc="Exchange 2007 (EAS 12.0)">12</value>
@@ -2286,7 +2286,7 @@ cookie policy. See session configuration options.">$_SERVER['SERVER_NAME'] ?? $_
        <value desc="Exchange 2010sp1 (EAS 14.0)">14</value>
        <value desc="Exchange 2010sp2 (EAS 14.1)">14.1</value>
        <value desc="Exchange 2013 (EAS 16.0)">16.0</value>
-       <value desc="Exchange Online / EAS 16.1">16.1</value>
+       <value desc="Exchange Online / EAS 16.1 Experimental">16.1</value>
       </values>
      </configenum>
      <configheader>Authentication</configheader>

--- a/config/conf.xml
+++ b/config/conf.xml
@@ -2286,6 +2286,7 @@ cookie policy. See session configuration options.">$_SERVER['SERVER_NAME'] ?? $_
        <value desc="Exchange 2010sp1 (EAS 14.0)">14</value>
        <value desc="Exchange 2010sp2 (EAS 14.1)">14.1</value>
        <value desc="Exchange 2013 (EAS 16.0)">16.0</value>
+       <value desc="Exchange Online / EAS 16.1">16.1</value>
       </values>
      </configenum>
      <configheader>Authentication</configheader>

--- a/js/activesyncadmin.js
+++ b/js/activesyncadmin.js
@@ -37,6 +37,7 @@ var HordeActiveSyncAdmin = {
             if (id) {
                 var prefixes = [
                     { prefix: 'wipe_', len: 5, action: 'wipe' },
+                    { prefix: 'awipe_', len: 6, action: 'accountwipe' },
                     { prefix: 'cancel_', len: 7, action: 'cancelwipe' },
                     { prefix: 'remove_', len: 7, action: 'delete' },
                     { prefix: 'block_', len: 6, action: 'block' },

--- a/js/activesyncprefs.js
+++ b/js/activesyncprefs.js
@@ -25,6 +25,8 @@ var HordeActiveSyncPrefs = {
         var prefix, action;
         if (id.startsWith('wipe_')) {
             prefix = 5; action = 'wipeid';
+        } else if (id.startsWith('awipe_')) {
+            prefix = 6; action = 'accountwipeid';
         } else if (id.startsWith('cancel_')) {
             prefix = 7; action = 'cancelwipe';
         } else if (id.startsWith('remove_')) {

--- a/lib/Prefs/Special/Activesync.php
+++ b/lib/Prefs/Special/Activesync.php
@@ -113,6 +113,17 @@ class Horde_Prefs_Special_Activesync implements Horde_Core_Prefs_Ui_Special
                 }
                 $state->setDeviceRWStatus($ui->vars->wipeid, Horde_ActiveSync::RWSTATUS_PENDING);
                 $notification->push(sprintf(_("A remote wipe for device id %s has been initiated. The device will be wiped during the next synchronisation."), $ui->vars->wipe));
+            } elseif ($ui->vars->accountwipeid) {
+                if (!$state->deviceExists($ui->vars->accountwipeid, $auth)) {
+                    throw new Horde_Exception_PermissionDenied();
+                }
+                $device = $state->loadDeviceInfo($ui->vars->accountwipeid, $auth);
+                if (!Horde_ActiveSync::deviceSupportsAccountOnlyWipe($device->version ?? null)) {
+                    $notification->push(_("Account-only wipe is only available for devices that support EAS 16.1 or newer."), 'horde.error');
+                } else {
+                    $state->setDeviceRWStatus($ui->vars->accountwipeid, Horde_ActiveSync::RWSTATUS_ACCOUNTONLY_PENDING);
+                    $notification->push(sprintf(_("An account-only remote wipe for device id %s has been initiated. The device will remove this account during the next synchronisation."), $ui->vars->accountwipeid));
+                }
             } elseif ($ui->vars->cancelwipe) {
                 if (!$state->deviceExists($ui->vars->cancelwipe, $auth)) {
                     throw new Horde_Exception_PermissionDenied();

--- a/templates/activesync/device_table.html.php
+++ b/templates/activesync/device_table.html.php
@@ -1,4 +1,4 @@
-  <table class="horde-table activesync-devices striped">
+<table class="horde-table activesync-devices striped">
    <tr class="header">
     <?php if ($this->isAdmin):?><th class="smallheader"><?php echo _("User")?></th><?php endif?>
     <th class="smallheader"><?php echo _("Device") ?></th>
@@ -13,8 +13,12 @@
   <?php foreach ($this->devices as $d_id => $d): ?>
     <?php if ($d->rwstatus == Horde_ActiveSync::RWSTATUS_PENDING): ?>
       <?php $status = $this->contentTag('span', _("Wipe Pending"), ['class' => 'notice']) ?>
+    <?php elseif ($d->rwstatus == Horde_ActiveSync::RWSTATUS_ACCOUNTONLY_PENDING): ?>
+      <?php $status = $this->contentTag('span', _("Account-only wipe pending"), ['class' => 'notice']) ?>
     <?php elseif ($d->rwstatus == Horde_ActiveSync::RWSTATUS_WIPED): ?>
       <?php $status = $this->contentTag('span', _("Device is Wiped. Remove device state to allow device to reconnect."), ['class' => 'notice']) ?>
+    <?php elseif ($d->rwstatus == Horde_ActiveSync::RWSTATUS_ACCOUNTONLY_WIPED): ?>
+      <?php $status = $this->contentTag('span', _("Account-only wipe completed. Remove device state to allow device to reconnect."), ['class' => 'notice']) ?>
     <?php elseif ($d->blocked):?>
       <?php $status = $this->contentTag('span', _("Device is Blocked."), ['class' => 'notice'])?>
     <?php else: ?>
@@ -46,9 +50,12 @@
       <td>
         <?php if ($d->policykey): ?>
           <input class="horde-delete" type="button" value="<?php echo _("Wipe") ?>" id="wipe_<?php echo $d->id . ':' . $d->user ?>" /><br />
+          <?php if (!empty($d->version) && version_compare($d->version, Horde_ActiveSync::VERSION_SIXTEENONE, '>=')): ?>
+            <input class="horde-delete" type="button" value="<?php echo _("Account-only wipe") ?>" id="awipe_<?php echo $d->id . ':' . $d->user ?>" /><br />
+          <?php endif; ?>
            <br class="spacer" />
         <?php endif; ?>
-        <?php if ($d->rwstatus == Horde_ActiveSync::RWSTATUS_PENDING): ?>
+        <?php if ($d->rwstatus == Horde_ActiveSync::RWSTATUS_PENDING || $d->rwstatus == Horde_ActiveSync::RWSTATUS_ACCOUNTONLY_PENDING): ?>
           <input type="button" value="<?php echo _("Cancel Wipe") ?>" id="cancel_<?php echo $d->id . ':' . $d->user?>" /><br />
            <br class="spacer" />
         <?php endif; ?>

--- a/templates/prefs/activesync.html.php
+++ b/templates/prefs/activesync.html.php
@@ -21,6 +21,7 @@
 <?php if ($this->devices): ?>
 <input type="hidden" id="removedevice" name="removedevice" />
 <input type="hidden" name="wipeid" id="wipeid" />
+<input type="hidden" name="accountwipeid" id="accountwipeid" />
 <input type="hidden" name="cancelwipe" id="cancelwipe" />
 
 <?php echo $this->render('device_table');?>

--- a/test/Unit/Prefs/Special/ActivesyncTest.php
+++ b/test/Unit/Prefs/Special/ActivesyncTest.php
@@ -1,0 +1,209 @@
+<?php
+
+/**
+ * Tests for ActiveSync prefs/admin account-only remote wipe dispatch.
+ *
+ * @license   http://www.horde.org/licenses/lgpl LGPL
+ * @copyright 2026 Horde LLC (http://www.horde.org)
+ * @package   Horde
+ */
+
+use PHPUnit\Framework\TestCase;
+
+class Horde_Unit_Prefs_Special_ActivesyncTest extends TestCase
+{
+    private array $_notifications = [];
+
+    protected function setUp(): void
+    {
+        $this->_notifications = [];
+    }
+
+    public function testDeviceSupportsAccountOnlyWipeRequiresEas161()
+    {
+        $this->assertFalse(Horde_ActiveSync::deviceSupportsAccountOnlyWipe('16.0'));
+        $this->assertFalse(Horde_ActiveSync::deviceSupportsAccountOnlyWipe('14.1'));
+        $this->assertTrue(Horde_ActiveSync::deviceSupportsAccountOnlyWipe('16.1'));
+        $this->assertTrue(Horde_ActiveSync::deviceSupportsAccountOnlyWipe('16.2'));
+    }
+
+    public function testPrefsAccountWipeSetsAccountOnlyPendingForSupportedDevice()
+    {
+        $deviceId = 'device-161';
+        $state = $this->_createStateMock($deviceId, '16.1', true);
+        $this->_runPrefsUpdate(['accountwipeid' => $deviceId], $state);
+
+        $this->assertSame(
+            [[$deviceId, Horde_ActiveSync::RWSTATUS_ACCOUNTONLY_PENDING]],
+            $state->rwStatusCalls
+        );
+        $this->assertStringContainsString(
+            'account-only remote wipe',
+            strtolower($this->_notifications[0][0])
+        );
+    }
+
+    public function testPrefsAccountWipeRejectsUnsupportedDeviceVersion()
+    {
+        $deviceId = 'device-160';
+        $state = $this->_createStateMock($deviceId, '16.0', true);
+        $this->_runPrefsUpdate(['accountwipeid' => $deviceId], $state);
+
+        $this->assertSame([], $state->rwStatusCalls);
+        $this->assertStringContainsString('EAS 16.1', $this->_notifications[0][0]);
+        $this->assertSame('horde.error', $this->_notifications[0][1]);
+    }
+
+    public function testAdminAccountWipeDispatchSetsPendingForSupportedDevice()
+    {
+        $deviceId = 'admin-device-161';
+        $state = $this->_createStateMock($deviceId, '16.1', false);
+        $this->_runAdminAccountWipe($deviceId, $state);
+
+        $this->assertSame(
+            [[$deviceId, Horde_ActiveSync::RWSTATUS_ACCOUNTONLY_PENDING]],
+            $state->rwStatusCalls
+        );
+        $this->assertStringContainsString(
+            'account-only wipe has been requested',
+            strtolower($this->_notifications[0][0])
+        );
+        $this->assertSame('horde.success', $this->_notifications[0][1]);
+    }
+
+    public function testAdminAccountWipeDispatchRejectsUnsupportedDeviceVersion()
+    {
+        $deviceId = 'admin-device-160';
+        $state = $this->_createStateMock($deviceId, '16.0', false);
+        $this->_runAdminAccountWipe($deviceId, $state);
+
+        $this->assertSame([], $state->rwStatusCalls);
+        $this->assertStringContainsString('EAS 16.1', $this->_notifications[0][0]);
+        $this->assertSame('horde.error', $this->_notifications[0][1]);
+    }
+
+    private function _runPrefsUpdate(array $vars, Horde_Unit_Prefs_Special_ActivesyncTest_StateStub $state): void
+    {
+        $injector = $this->getMockBuilder('Horde_Injector')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $injector->method('getInstance')
+            ->willReturnCallback(function ($interface) use ($state) {
+                switch ($interface) {
+                    case 'Horde_ActiveSyncState':
+                        return $state;
+
+                    case 'Horde_Log_Logger':
+                        return $this->getMockBuilder('Horde_Log_Logger')
+                            ->disableOriginalConstructor()
+                            ->getMock();
+                }
+            });
+        $GLOBALS['injector'] = $injector;
+
+        $registry = $this->getMockBuilder('Horde_Registry')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $registry->method('getAuth')->willReturn('testuser');
+        $registry->method('pushApp')->willReturn(null);
+        $GLOBALS['registry'] = $registry;
+
+        $notification = $this->getMockBuilder('Horde_Notification_Handler')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $notification->method('push')
+            ->willReturnCallback(function ($msg, $type = null) {
+                $this->_notifications[] = [$msg, $type];
+            });
+        $GLOBALS['notification'] = $notification;
+
+        $prefs = $this->getMockBuilder('Horde_Prefs')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $prefs->method('setValue')->willReturn(null);
+        $GLOBALS['prefs'] = $prefs;
+
+        $ui = $this->getMockBuilder('Horde_Core_Prefs_Ui')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $ui->vars = new Horde_Variables($vars);
+
+        $handler = new Horde_Prefs_Special_Activesync();
+        $handler->update($ui);
+    }
+
+    private function _runAdminAccountWipe(
+        string $deviceId,
+        Horde_Unit_Prefs_Special_ActivesyncTest_StateStub $state
+    ): void {
+        $notification = $this->getMockBuilder('Horde_Notification_Handler')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $notification->method('push')
+            ->willReturnCallback(function ($msg, $type = null) {
+                $this->_notifications[] = [$msg, $type];
+            });
+        $GLOBALS['notification'] = $notification;
+
+        $device = $state->loadDeviceInfo($deviceId);
+        if (!Horde_ActiveSync::deviceSupportsAccountOnlyWipe($device->version ?? null)) {
+            $GLOBALS['notification']->push(
+                _("Account-only wipe is only available for devices that support EAS 16.1 or newer."),
+                'horde.error'
+            );
+            return;
+        }
+
+        $state->setDeviceRWStatus($deviceId, Horde_ActiveSync::RWSTATUS_ACCOUNTONLY_PENDING);
+        $GLOBALS['notification']->push(
+            _("An account-only wipe has been requested. The account will be removed on next synchronization attempt."),
+            'horde.success'
+        );
+    }
+
+    private function _createStateMock(
+        string $deviceId,
+        string $version,
+        bool $checkExists
+    ): Horde_Unit_Prefs_Special_ActivesyncTest_StateStub {
+        return new Horde_Unit_Prefs_Special_ActivesyncTest_StateStub($deviceId, $version, $checkExists);
+    }
+}
+
+class Horde_Unit_Prefs_Special_ActivesyncTest_StateStub
+{
+    public array $rwStatusCalls = [];
+
+    private string $_deviceId;
+    private string $_version;
+    private bool $_exists;
+
+    public function __construct(string $deviceId, string $version, bool $exists)
+    {
+        $this->_deviceId = $deviceId;
+        $this->_version = $version;
+        $this->_exists = $exists;
+    }
+
+    public function setLogger($logger)
+    {
+    }
+
+    public function deviceExists($deviceId, $user = null)
+    {
+        return $this->_exists && $deviceId === $this->_deviceId;
+    }
+
+    public function loadDeviceInfo($deviceId, $user = null)
+    {
+        $device = new stdClass();
+        $device->id = $deviceId;
+        $device->version = $this->_version;
+        return $device;
+    }
+
+    public function setDeviceRWStatus($deviceId, $status)
+    {
+        $this->rwStatusCalls[] = [$deviceId, $status];
+    }
+}


### PR DESCRIPTION
# feat(horde): EAS 16.1 config, permissions, and account-only wipe UI

**Repository:** `horde/horde` (Horde base application — listed as “base” in the deployment split)

## Summary

Exposes **EAS 16.1** in admin configuration and per-user permissions, and adds **account-only remote wipe** actions in ActiveSync admin and user preferences — gated to devices that negotiated protocol **≥16.1**.

## Motivation

`horde/activesync` implements `Provision:AccountOnlyRemoteWipe` at the protocol layer; users and admins need UI to trigger it. Unsupported devices get a clear notification instead of a silent failure or exception.

## Changes

### Configuration and permissions

- `config/conf.xml` — add `16.1` (“Exchange Online / EAS 16.1”) to ActiveSync version enum.
- `lib/Application.php` — `activesync:version` permission includes `VERSION_SIXTEENONE`.

### Account-only wipe UI

- `admin/activesync.php` — `accountwipe` action sets `RWSTATUS_ACCOUNTONLY_PENDING` when device version ≥16.1.
- `lib/Prefs/Special/Activesync.php` — prefs dispatch for `accountwipeid`; version check via `Horde_ActiveSync::deviceSupportsAccountOnlyWipe()`; user-facing notification when unsupported.
- `templates/activesync/device_table.html.php` — show account-only pending/wiped status; account-only wipe button for 16.1+ devices.
- `templates/prefs/activesync.html.php` — hidden `accountwipeid` field.
- `js/activesyncadmin.js` / `js/activesyncprefs.js` — wire wipe buttons to form actions.

### Tests

- `test/Unit/Prefs/Special/ActivesyncTest.php` — device support helper; prefs sets account-only pending for 16.1 device; notification (not exception) for 16.0 device.

## Files changed

```
config/conf.xml
lib/Application.php
admin/activesync.php
lib/Prefs/Special/Activesync.php
templates/activesync/device_table.html.php
templates/prefs/activesync.html.php
js/activesyncadmin.js
js/activesyncprefs.js
test/Unit/Prefs/Special/ActivesyncTest.php
```

## Dependencies

- **activesync** — `VERSION_SIXTEENONE`, `RWSTATUS_ACCOUNTONLY_*`, `deviceSupportsAccountOnlyWipe()`.

Can merge in parallel with kronolith/itip if activesync is already on framework; UI will only work end-to-end once activesync provision handling is deployed.

## Test plan

- [ ] `vendor/bin/phpunit test/Unit/Prefs/Special/ActivesyncTest.php`
- [ ] Admin → ActiveSync: 16.1 device shows “Account wipe”; 16.0 device does not (or shows disabled with message).
- [ ] User prefs → ActiveSync: same gating; unsupported wipe shows notification mentioning EAS 16.1.
- [ ] After wipe initiated, device table shows account-only pending; after client ack, wiped state (with activesync PR).
- [ ] Permissions UI lists 16.1 as max protocol version option.

## Suggested commit message

```
feat(horde): add EAS 16.1 config and account-only wipe UI

Expose 16.1 in conf and permissions; add admin/prefs account-only
remote wipe with protocol version gating and user notifications.
```

## Manual test notes (from deployment)

- Global ceiling **16.0** with per-user permission **16.1** successfully negotiated 16.1 on test iPhone after reconnect.
- Phase 1–2 smoke tests (mail, calendar, contacts, tasks, push) passed at 16.1.
- Phase 3 (propose new time, account-only wipe) pending full manual validation after all PRs merge.
