### PR TITLE
fix(horde): persist classic portal layout saves reliably

### DIFF
--- a/services/portal/edit.php
+++ b/services/portal/edit.php
@@ -14,23 +14,56 @@
  * @package  Horde
  */
 
-use Horde\Util\Variables;
+use Horde\Util\Util;
 
 require_once __DIR__ . '/../../lib/Application.php';
 Horde_Registry::appInit('horde');
 
 $blocks = $injector->getInstance('Horde_Core_Factory_BlockCollection')->create();
 $layout = $blocks->getLayoutManager();
-$vars = $injector->getInstance(Variables::class);
 
-// Handle requested actions.
-$layout->handle($vars->action, intval($vars->row), intval($vars->col));
+$action = Util::getFormData('action');
+$row = intval(Util::getFormData('row'));
+$col = intval(Util::getFormData('col'));
+
+if ($prefs->isLocked('portal_layout')
+    && in_array($action, ['save', 'save-resume'], true)) {
+    $notification->push(
+        _('The portal layout has been locked by the administrator and cannot be changed.'),
+        'horde.error'
+    );
+} else {
+    try {
+        $layout->handle($action, $row, $col);
+    } catch (Horde_Exception $e) {
+        Horde::log($e, Horde_Log::ERR);
+        $notification->push($e, 'horde.error');
+    }
+}
 
 if ($layout->updated()) {
-    $prefs->setValue('portal_layout', $layout->serialize());
-    if ($url = Horde::verifySignedUrl($vars->url)) {
-        $url = new Horde_Url($url);
-        $url->unique()->redirect();
+    if ($prefs->isLocked('portal_layout')) {
+        $notification->push(
+            _('The portal layout has been locked by the administrator and cannot be changed.'),
+            'horde.error'
+        );
+    } elseif (!$prefs->setValue('portal_layout', $layout->serialize())) {
+        $notification->push(
+            _('Failed to save the portal layout.'),
+            'horde.error'
+        );
+    } else {
+        try {
+            $prefs->store(true);
+            $notification->push(_('Portal layout saved.'), 'horde.message');
+            if ($url = Horde::verifySignedUrl(Util::getFormData('url'))) {
+                $url = new Horde_Url($url);
+                $url->unique()->redirect();
+            }
+        } catch (Horde_Exception $e) {
+            Horde::log($e, Horde_Log::ERR);
+            $notification->push($e, 'horde.error');
+        }
     }
 }
 

--- a/services/portal/edit.php
+++ b/services/portal/edit.php
@@ -22,12 +22,18 @@ Horde_Registry::appInit('horde');
 $blocks = $injector->getInstance('Horde_Core_Factory_BlockCollection')->create();
 $layout = $blocks->getLayoutManager();
 
-$action = Util::getFormData('action');
-$row = intval(Util::getFormData('row'));
-$col = intval(Util::getFormData('col'));
+$action = (string) Util::getFormData('action');
+$row = (int) Util::getFormData('row');
+$col = (int) Util::getFormData('col');
 
-if ($prefs->isLocked('portal_layout')
-    && in_array($action, ['save', 'save-resume'], true)) {
+$layoutLocked = $prefs->isLocked('portal_layout');
+$blockedAction = ($action === 'save')
+    || ($action === 'save-resume')
+    || str_starts_with($action, 'move/')
+    || str_starts_with($action, 'expand/')
+    || str_starts_with($action, 'shrink/');
+
+if ($layoutLocked && $blockedAction) {
     $notification->push(
         _('The portal layout has been locked by the administrator and cannot be changed.'),
         'horde.error'


### PR DESCRIPTION
## Summary
- Read portal edit actions via `Util::getFormData()` instead of injected request vars
- Surface layout handle errors and locked `portal_layout` pref state to the user
- Call `prefs->store(true)` after `setValue()` so layout changes persist immediately

## Motivation
Saving blocks on the classic portal (`/horde/services/portal/edit.php`) could appear to succeed while nothing was written, especially when prefs storage failed quietly or the layout pref was locked.

## Changes
- `services/portal/edit.php`: error handling, locked-pref checks, explicit pref store, success notification

## Test plan
- [ ] Add a block on `/horde/services/portal/edit.php` and save
- [ ] Verify it appears on `/horde/services/portal/`
- [ ] With `portal_layout` locked, confirm save is blocked with a clear message
- [ ] Confirm a success notification is shown after a normal save

Made with [Cursor](https://cursor.com)