### PR TITLE
fix(horde): account-only wipe admin and prefs reliability

### DIFF
--- a/admin/activesync.php
+++ b/admin/activesync.php
@@ -51,10 +51,10 @@ if ($state) {
     $state->setLogger($injector->getInstance('Horde_Log_Logger'));
 
     if ($actionID = Util::getPost('actionID')) {
-        $deviceID = Util::getPost('deviceID');
-
-        $device_desc = explode(':', $deviceID);
+        $deviceIDRaw = Util::getPost('deviceID');
+        $device_desc = explode(':', $deviceIDRaw, 2);
         $deviceID = $device_desc[0];
+        $actionUser = Util::getPost('uid') ?: ($device_desc[1] ?? null);
 
         switch ($actionID) {
             case 'wipe':
@@ -63,16 +63,31 @@ if ($state) {
                 break;
 
             case 'accountwipe':
-                $device = $state->loadDeviceInfo($deviceID);
+                if (empty($actionUser)) {
+                    $GLOBALS['notification']->push(_("Unable to determine which account to wipe."), 'horde.error');
+                    break;
+                }
+                $device = $state->loadDeviceInfo($deviceID, $actionUser);
                 if (!Horde_ActiveSync::deviceSupportsAccountOnlyWipe($device->version ?? null)) {
                     $GLOBALS['notification']->push(_("Account-only wipe requires a device with EAS 16.1 or newer."), 'horde.error');
                     break;
                 }
-                $state->setDeviceRWStatus($deviceID, Horde_ActiveSync::RWSTATUS_ACCOUNTONLY_PENDING);
+                $state->setAccountOnlyRWStatus(
+                    $deviceID,
+                    $actionUser,
+                    Horde_ActiveSync::RWSTATUS_ACCOUNTONLY_PENDING
+                );
                 $GLOBALS['notification']->push(_("An account-only wipe has been requested. The account will be removed from the device on the next synchronization."), 'horde.success');
                 break;
 
             case 'cancelwipe':
+                if (!empty($actionUser)) {
+                    $state->setAccountOnlyRWStatus(
+                        $deviceID,
+                        $actionUser,
+                        Horde_ActiveSync::RWSTATUS_OK
+                    );
+                }
                 $state->setDeviceRWStatus($deviceID, Horde_ActiveSync::RWSTATUS_OK);
                 $GLOBALS['notification']->push(_("Device wipe successfully canceled."), 'horde.success');
                 break;
@@ -81,7 +96,8 @@ if ($state) {
                 $state->removeState(
                     [
                         'devId' => $deviceID,
-                        'user' => Util::getPost('uid')]
+                        'user' => $actionUser,
+                    ]
                 );
                 $GLOBALS['notification']->push(_("Device successfully removed."), 'horde.success');
                 break;

--- a/admin/activesync.php
+++ b/admin/activesync.php
@@ -93,6 +93,10 @@ if ($state) {
                 break;
 
             case 'delete':
+                if (empty($actionUser)) {
+                    $GLOBALS['notification']->push(_("Unable to determine which account to delete."), 'horde.error');
+                    break;
+                }
                 $state->removeState(
                     [
                         'devId' => $deviceID,

--- a/js/activesyncadmin.js
+++ b/js/activesyncadmin.js
@@ -46,11 +46,23 @@ var HordeActiveSyncAdmin = {
 
                 for (var i = 0; i < prefixes.length; i++) {
                     if (id.startsWith(prefixes[i].prefix)) {
-                        var device = this.devices[id.substr(prefixes[i].len)];
-                        document.getElementById('deviceID').value = device.id;
+                        var deviceKey = id.substr(prefixes[i].len);
+                        var device = this.devices[deviceKey];
+                        if (!device && deviceKey.indexOf(':') !== -1) {
+                            var parts = deviceKey.split(':', 2);
+                            device = { id: parts[0], user: parts[1] };
+                        }
+                        if (!device) {
+                            break;
+                        }
                         document.getElementById('actionID').value = prefixes[i].action;
-                        if (prefixes[i].action === 'delete') {
+                        if (prefixes[i].action === 'delete'
+                            || prefixes[i].action === 'accountwipe'
+                            || prefixes[i].action === 'cancelwipe') {
                             document.getElementById('uid').value = device.user;
+                            document.getElementById('deviceID').value = device.id + ':' + device.user;
+                        } else {
+                            document.getElementById('deviceID').value = device.id;
                         }
                         form.submit();
                         e.preventDefault();

--- a/lib/Prefs/Special/Activesync.php
+++ b/lib/Prefs/Special/Activesync.php
@@ -139,7 +139,7 @@ class Horde_Prefs_Special_Activesync implements Horde_Core_Prefs_Ui_Special
                 }
                 $state->setAccountOnlyRWStatus($ui->vars->cancelwipe, $auth, Horde_ActiveSync::RWSTATUS_OK);
                 $state->setDeviceRWStatus($ui->vars->cancelwipe, Horde_ActiveSync::RWSTATUS_OK);
-                $notification->push(sprintf(_("The Remote Wipe for device id %s has been cancelled."), $ui->vars->wipe));
+                $notification->push(sprintf(_("The Remote Wipe for device id %s has been cancelled."), $ui->vars->cancelwipe));
             } elseif ($ui->vars->reset) {
                 $devices = $state->listDevices($auth);
                 foreach ($devices as $device) {

--- a/lib/Prefs/Special/Activesync.php
+++ b/lib/Prefs/Special/Activesync.php
@@ -126,13 +126,18 @@ class Horde_Prefs_Special_Activesync implements Horde_Core_Prefs_Ui_Special
                 if (!Horde_ActiveSync::deviceSupportsAccountOnlyWipe($device->version ?? null)) {
                     $notification->push(_("Account-only wipe requires a device with EAS 16.1 or newer."), 'horde.error');
                 } else {
-                    $state->setDeviceRWStatus($ui->vars->accountwipeid, Horde_ActiveSync::RWSTATUS_ACCOUNTONLY_PENDING);
+                    $state->setAccountOnlyRWStatus(
+                        $ui->vars->accountwipeid,
+                        $auth,
+                        Horde_ActiveSync::RWSTATUS_ACCOUNTONLY_PENDING
+                    );
                     $notification->push(sprintf(_("An account-only wipe for device %s has been initiated. The account will be removed during the next synchronisation."), $ui->vars->accountwipeid));
                 }
             } elseif ($ui->vars->cancelwipe) {
                 if (!$state->deviceExists($ui->vars->cancelwipe, $auth)) {
                     throw new Horde_Exception_PermissionDenied();
                 }
+                $state->setAccountOnlyRWStatus($ui->vars->cancelwipe, $auth, Horde_ActiveSync::RWSTATUS_OK);
                 $state->setDeviceRWStatus($ui->vars->cancelwipe, Horde_ActiveSync::RWSTATUS_OK);
                 $notification->push(sprintf(_("The Remote Wipe for device id %s has been cancelled."), $ui->vars->wipe));
             } elseif ($ui->vars->reset) {

--- a/locale/horde.pot
+++ b/locale/horde.pot
@@ -202,6 +202,10 @@ msgid ""
 "syncronization attempt."
 msgstr ""
 
+#: admin/activesync.php:67
+msgid "Unable to determine which account to wipe."
+msgstr ""
+
 #: admin/config/index.php:174 admin/config/index.php:218
 #: admin/config/index.php:360 admin/config/index.php:386
 #, php-format

--- a/locale/horde.pot
+++ b/locale/horde.pot
@@ -3386,6 +3386,10 @@ msgstr ""
 msgid "Unable to delete \"%s\": %s."
 msgstr ""
 
+#: admin/activesync.php:97
+msgid "Unable to determine which account to delete."
+msgstr ""
+
 #: lib/Ajax/Application/FacebookHandler.php:119
 msgid "Unable to set like."
 msgstr ""

--- a/templates/activesync/device_table.html.php
+++ b/templates/activesync/device_table.html.php
@@ -38,11 +38,11 @@ $adminCols = $this->isAdmin ? ($grouped ? 6 : 7) : 5;
     <?php $deviceCollections = $entry['collections']; ?>
     <?php if ($d->rwstatus == Horde_ActiveSync::RWSTATUS_PENDING): ?>
       <?php $status = $this->contentTag('span', _("Device wipe pending"), ['class' => 'notice']) ?>
-    <?php elseif ($d->rwstatus == Horde_ActiveSync::RWSTATUS_ACCOUNTONLY_PENDING): ?>
+    <?php elseif (!empty($d->accountOnlyRwstatus) && $d->accountOnlyRwstatus == Horde_ActiveSync::RWSTATUS_ACCOUNTONLY_PENDING): ?>
       <?php $status = $this->contentTag('span', _("Account wipe pending"), ['class' => 'notice']) ?>
     <?php elseif ($d->rwstatus == Horde_ActiveSync::RWSTATUS_WIPED): ?>
       <?php $status = $this->contentTag('span', _("Device wiped. Remove device state to allow the device to reconnect."), ['class' => 'notice']) ?>
-    <?php elseif ($d->rwstatus == Horde_ActiveSync::RWSTATUS_ACCOUNTONLY_WIPED): ?>
+    <?php elseif (!empty($d->accountOnlyRwstatus) && $d->accountOnlyRwstatus == Horde_ActiveSync::RWSTATUS_ACCOUNTONLY_WIPED): ?>
       <?php $status = $this->contentTag('span', _("Account wiped. Remove device state to allow the device to reconnect."), ['class' => 'notice']) ?>
     <?php elseif ($d->blocked):?>
       <?php $status = $this->contentTag('span', _("Device is Blocked."), ['class' => 'notice'])?>
@@ -105,7 +105,9 @@ $adminCols = $this->isAdmin ? ($grouped ? 6 : 7) : 5;
             <input class="horde-delete" type="button" value="<?php echo _("Wipe account") ?>" id="awipe_<?php echo $d->id . ':' . $d->user ?>" />
           <?php endif; ?>
         <?php endif; ?>
-        <?php if ($d->rwstatus == Horde_ActiveSync::RWSTATUS_PENDING || $d->rwstatus == Horde_ActiveSync::RWSTATUS_ACCOUNTONLY_PENDING): ?>
+        <?php if ($d->rwstatus == Horde_ActiveSync::RWSTATUS_PENDING
+            || (!empty($d->accountOnlyRwstatus)
+                && $d->accountOnlyRwstatus == Horde_ActiveSync::RWSTATUS_ACCOUNTONLY_PENDING)): ?>
           <input type="button" value="<?php echo _("Cancel wipe") ?>" id="cancel_<?php echo $d->id . ':' . $d->user?>" />
         <?php endif; ?>
         <input class="horde-delete" type="button" value="<?php echo _("Remove device state") ?>" id="remove_<?php echo $d->id . ':' . $d->user ?>" />

--- a/test/Unit/Prefs/Special/ActivesyncTest.php
+++ b/test/Unit/Prefs/Special/ActivesyncTest.php
@@ -34,9 +34,10 @@ class Horde_Unit_Prefs_Special_ActivesyncTest extends TestCase
         $this->_runPrefsUpdate(['accountwipeid' => $deviceId], $state);
 
         $this->assertSame(
-            [[$deviceId, Horde_ActiveSync::RWSTATUS_ACCOUNTONLY_PENDING]],
-            $state->rwStatusCalls
+            [['device-161', 'testuser', Horde_ActiveSync::RWSTATUS_ACCOUNTONLY_PENDING]],
+            $state->accountOnlyRwStatusCalls
         );
+        $this->assertSame([], $state->rwStatusCalls);
         $this->assertStringContainsString(
             'account-only wipe',
             strtolower($this->_notifications[0][0])
@@ -49,6 +50,7 @@ class Horde_Unit_Prefs_Special_ActivesyncTest extends TestCase
         $state = $this->_createStateMock($deviceId, '16.0', true);
         $this->_runPrefsUpdate(['accountwipeid' => $deviceId], $state);
 
+        $this->assertSame([], $state->accountOnlyRwStatusCalls);
         $this->assertSame([], $state->rwStatusCalls);
         $this->assertStringContainsString('EAS 16.1', $this->_notifications[0][0]);
         $this->assertSame('horde.error', $this->_notifications[0][1]);
@@ -61,9 +63,10 @@ class Horde_Unit_Prefs_Special_ActivesyncTest extends TestCase
         $this->_runAdminAccountWipe($deviceId, $state);
 
         $this->assertSame(
-            [[$deviceId, Horde_ActiveSync::RWSTATUS_ACCOUNTONLY_PENDING]],
-            $state->rwStatusCalls
+            [['admin-device-161', 'testuser', Horde_ActiveSync::RWSTATUS_ACCOUNTONLY_PENDING]],
+            $state->accountOnlyRwStatusCalls
         );
+        $this->assertSame([], $state->rwStatusCalls);
         $this->assertStringContainsString(
             'account-only wipe has been requested',
             strtolower($this->_notifications[0][0])
@@ -77,6 +80,7 @@ class Horde_Unit_Prefs_Special_ActivesyncTest extends TestCase
         $state = $this->_createStateMock($deviceId, '16.0', false);
         $this->_runAdminAccountWipe($deviceId, $state);
 
+        $this->assertSame([], $state->accountOnlyRwStatusCalls);
         $this->assertSame([], $state->rwStatusCalls);
         $this->assertStringContainsString('EAS 16.1', $this->_notifications[0][0]);
         $this->assertSame('horde.error', $this->_notifications[0][1]);
@@ -134,7 +138,8 @@ class Horde_Unit_Prefs_Special_ActivesyncTest extends TestCase
 
     private function _runAdminAccountWipe(
         string $deviceId,
-        Horde_Unit_Prefs_Special_ActivesyncTest_StateStub $state
+        Horde_Unit_Prefs_Special_ActivesyncTest_StateStub $state,
+        string $user = 'testuser'
     ): void {
         $notification = $this->getMockBuilder('Horde_Notification_Handler')
             ->disableOriginalConstructor()
@@ -154,7 +159,11 @@ class Horde_Unit_Prefs_Special_ActivesyncTest extends TestCase
             return;
         }
 
-        $state->setDeviceRWStatus($deviceId, Horde_ActiveSync::RWSTATUS_ACCOUNTONLY_PENDING);
+        $state->setAccountOnlyRWStatus(
+            $deviceId,
+            $user,
+            Horde_ActiveSync::RWSTATUS_ACCOUNTONLY_PENDING
+        );
         $GLOBALS['notification']->push(
             _("An account-only wipe has been requested. The account will be removed from the device on the next synchronization."),
             'horde.success'
@@ -173,6 +182,7 @@ class Horde_Unit_Prefs_Special_ActivesyncTest extends TestCase
 class Horde_Unit_Prefs_Special_ActivesyncTest_StateStub
 {
     public array $rwStatusCalls = [];
+    public array $accountOnlyRwStatusCalls = [];
 
     private string $_deviceId;
     private string $_version;
@@ -205,5 +215,10 @@ class Horde_Unit_Prefs_Special_ActivesyncTest_StateStub
     public function setDeviceRWStatus($deviceId, $status)
     {
         $this->rwStatusCalls[] = [$deviceId, $status];
+    }
+
+    public function setAccountOnlyRWStatus($deviceId, $user, $status)
+    {
+        $this->accountOnlyRwStatusCalls[] = [$deviceId, $user, $status];
     }
 }

--- a/test/Unit/Prefs/Special/ActivesyncTest.php
+++ b/test/Unit/Prefs/Special/ActivesyncTest.php
@@ -86,6 +86,23 @@ class Horde_Unit_Prefs_Special_ActivesyncTest extends TestCase
         $this->assertSame('horde.error', $this->_notifications[0][1]);
     }
 
+    public function testPrefsCancelWipeClearsBothRWStatuses()
+    {
+        $deviceId = 'device-cancel';
+        $state = $this->_createStateMock($deviceId, '16.1', true);
+        $this->_runPrefsUpdate(['cancelwipe' => $deviceId], $state);
+
+        $this->assertSame(
+            [[$deviceId, 'testuser', Horde_ActiveSync::RWSTATUS_OK]],
+            $state->accountOnlyRwStatusCalls
+        );
+        $this->assertSame(
+            [[$deviceId, Horde_ActiveSync::RWSTATUS_OK]],
+            $state->rwStatusCalls
+        );
+        $this->assertNotEmpty($this->_notifications);
+    }
+
     private function _runPrefsUpdate(array $vars, Horde_Unit_Prefs_Special_ActivesyncTest_StateStub $state): void
     {
         $injector = $this->getMockBuilder('Horde_Injector')


### PR DESCRIPTION
## Summary
- Fix admin account-only wipe when `uid` is missing by parsing composite `deviceID` (`devId:user`) in JS and PHP
- Show per-user account-only wipe status in the device table (pending / wiped)
- Align user prefs wipe actions with per-user ActiveSync state

## Test plan
- [ ] Run `ActivesyncTest` unit tests
- [ ] Admin → ActiveSync: account-only wipe on device with multiple users targets the correct account
- [ ] Prefs → ActiveSync: same wipe flow works for own devices
- [ ] Wiped account shows correct status text; remove-state action still available

Depends on horde/ActiveSync account-only wipe state changes (migration 25).


Made with [Cursor](https://cursor.com)