### PR TITLE
fix(registry): stop pre-declaring optional content/timeobjects apps

### DIFF
--- a/config/registry.php
+++ b/config/registry.php
@@ -355,13 +355,4 @@ $this->applications = [
         'name' => _("Mail Admin"),
         'menu_parent' => 'administration',
     ],
-
-    'content' => [
-        'status' => 'hidden',
-    ],
-
-    'timeobjects' => [
-        'status' => 'hidden',
-        'provides' => 'timeobjects',
-    ],
 ];


### PR DESCRIPTION
Fixes horde/Core#177