### PR TITLE
fix(prefs): restore locale-aware time format defaults via ICU styles #22

### DIFF
--- a/config/prefs.php
+++ b/config/prefs.php
@@ -477,20 +477,22 @@ $_prefs['date_format_mini'] = [
 ];
 
 $_prefs['time_format'] = [
-    'value' => 'h:mm:ss a',
+    'value' => 'medium',
     'type' => 'enum',
     'enum' => [
-        'h:mm:ss a' => Format::formatDate(time(), 'h:mm:ss a', $GLOBALS['language'] ?? 'en_US') . ' (' . _("Default") . ')',
+        'medium' => Format::formatDate(time(), 'medium', $GLOBALS['language'] ?? 'en_US', Format::TIME_ONLY) . ' (' . _("Default") . ')',
+        'h:mm:ss a' => Format::formatDate(time(), 'h:mm:ss a', $GLOBALS['language'] ?? 'en_US') . ' (' . _("12-hour format") . ')',
         'HH:mm:ss' => Format::formatDate(time(), 'HH:mm:ss', $GLOBALS['language'] ?? 'en_US') . ' (' . _("24-hour format") . ')',
     ],
     'desc' => _("Choose how to display times (full format):"),
 ];
 
 $_prefs['time_format_mini'] = [
-    'value' => 'h:mm a',
+    'value' => 'short',
     'type' => 'enum',
     'enum' => [
-        'h:mm a' => Format::formatDate(time(), 'h:mm a', $GLOBALS['language'] ?? 'en_US') . ' (' . _("Default") . ')',
+        'medium' => Format::formatDate(time(), 'short', $GLOBALS['language'] ?? 'en_US', Format::TIME_ONLY) . ' (' . _("Default") . ')',
+        'h:mm a' => Format::formatDate(time(), 'h:mm a', $GLOBALS['language'] ?? 'en_US') . ' (' . _("12-hour format") . ')',
         'HH:mm' => Format::formatDate(time(), 'HH:mm', $GLOBALS['language'] ?? 'en_US') . ' (' . _("24-hour format") . ')',
     ],
     'desc' => _("Choose how to display times (abbreviated format):"),


### PR DESCRIPTION
**Title:** `fix(prefs): restore locale-aware time format defaults via ICU styles`

**Description:**

The default values for `time_format` and `time_format_mini` were hardcoded to `'h:mm:ss a'` and `'h:mm a'`, ignoring the user's locale. This is a regression from Horde 5 where `strftime('%X')` automatically produced the correct format for the locale.

Fix by using the named ICU styles `'medium'` and `'short'` as default values, which `Horde\Date\Format::formatDate()` already resolves via `IntlDateFormatter`.

Depends on `horde/Date` feat(format): add TIME_ONLY constant and $timeOnly parameter to formatDate().