### PR TITLE
fix: session not regenerated when redirect_on_logout is configured

### DIFF
--- a/src/Service/LoginService.php
+++ b/src/Service/LoginService.php
@@ -423,13 +423,6 @@ class LoginService
         $this->notification->detach('status');
         $this->notification->attach('status');
 
-        // Check redirect_on_logout config
-        if ($request->reason === Horde_Auth::REASON_LOGOUT
-            && !empty($this->conf['auth']['redirect_on_logout'])) {
-            $logoutUrl = $this->conf['auth']['redirect_on_logout'];
-            return ['redirect' => $logoutUrl, 'reason' => $request->reason];
-        }
-
         // Setup fresh anonymous session via the modern lifecycle.
         // SessionLifecycle::setup() is idempotent and replaces the
         // legacy shim's $GLOBALS['session']->setup() path that this
@@ -451,6 +444,13 @@ class LoginService
             $prefs->retrieve();
         } catch (Exception $e) {
             // Ignore - theme will use system default
+        }
+
+        // Check redirect_on_logout config
+        if ($request->reason === Horde_Auth::REASON_LOGOUT
+            && !empty($this->conf['auth']['redirect_on_logout'])) {
+            $logoutUrl = $this->conf['auth']['redirect_on_logout'];
+            return ['redirect' => $logoutUrl, 'reason' => $request->reason];
         }
 
         // Default redirect to login page


### PR DESCRIPTION
**Title:** `fix: session not regenerated when redirect_on_logout is configured`

**Body:**

```
## Bug

When `$conf['auth']['redirect_on_logout']` is set, logging out does not
destroy or regenerate the PHP session. The same session ID is reused on
the next login, which can leave the session in an inconsistent state and
cause errors such as:

  IMP is marked as authenticated, but no credentials can be found in the session.

## Root cause

`performLogout()` returns early when `redirect_on_logout` is configured,
before `sessionLifecycle->setup()` is called. The early return (cd5f9d8dd,
2026-05-11) predates the addition of `sessionLifecycle->setup()`
(7127e5c6d, 2026-06-12), which was placed after it by mistake.

## How I found it

I discovered this while rebasing PR #109 (refactor: delegate logout
handling from login.php to LoginService). With that change in place,
`login.php` routes all logouts through `performLogout()`, which made the
bug observable: repeated login/logout cycles did not resolve the issue —
the same session ID was reused every time, confirming that `setup()` was
never reached.

## Fix

Move the `redirect_on_logout` check after `sessionLifecycle->setup()`,
`setLanguage()` and `prefs->retrieve()`, so the session is always
regenerated before any redirect.
```