### PR TITLE
fix(services): cast Variables magic-property to string before substr() in download endpoint

### DIFF
--- a/services/download/index.php
+++ b/services/download/index.php
@@ -28,7 +28,7 @@ if (!isset($vars->app)) {
     exit;
 }
 
-$vars->filename = substr($vars->fn, 1);
+$vars->filename = substr((string) $vars->fn, 1);
 unset($vars->fn);
 
 $res = $registry->callAppMethod($vars->app, 'download', [


### PR DESCRIPTION
## Summary

`services/download/index.php:31` calls `substr($vars->fn, 1)` directly on the `Horde\Util\Variables` magic-property `$vars->fn`. When the `fn` query parameter is absent from the request, `$vars->fn` returns `null` and PHP 8.1+ emits:

```
substr(): Passing null to parameter #1 ($string) of type string is deprecated
```

This becomes a fatal in PHP 9. Cast to string before slicing.

```diff
-$vars->filename = substr($vars->fn, 1);
+$vars->filename = substr((string) $vars->fn, 1);
```

`null` casts to `""`, so when `fn` is missing the filename is set to the empty string. The downstream HTTP header line uses `$res['name'] ?? $vars->filename`, so the empty string only surfaces if the app's `download()` method also failed to return a `name` — same observable behaviour as before, minus the deprecation.

This is a **side aspect surfaced by the second comment in horde/imp#66**, not a fix for the actual session-decryption crash that issue tracks (that is addressed by horde/Core#174). Filing as a separate PR per maintainer guidance so each problem is reviewed on its own merits; will be linked back into #66 once the PR exists.