### PR TITLE
services download substr fix + topbar URL escaping

### DIFF
--- a/lib/View/Topbar.php
+++ b/lib/View/Topbar.php
@@ -48,7 +48,7 @@ class Horde_View_Topbar extends Horde_View
         $this->portalUrl = $registry->getServiceLink(
             'portal',
             $registry->getApp()
-        );
+        )->setRaw(true);
         if (class_exists('Horde_Bundle')) {
             $this->version = Horde_Bundle::SHORTNAME . ' ' . Horde_Bundle::VERSION;
         } else {
@@ -81,7 +81,7 @@ class Horde_View_Topbar extends Horde_View
                         'login',
                         $registry->getApp()
                     )
-                    ->setRaw(false)
+                    ->setRaw(true)
                     ->add('url', Horde::signUrl(Horde::selfUrl(true, true, true)));
             }
         }

--- a/templates/topbar/_menubar.html.php
+++ b/templates/topbar/_menubar.html.php
@@ -1,13 +1,13 @@
 <div id="horde-head">
-  <div id="horde-logo"><a class="icon" href="<?php echo $this->escape($this->portalUrl) ?>"></a></div>
+  <div id="horde-logo"><a class="icon" href="<?php echo $this->h($this->portalUrl) ?>"></a></div>
   <div id="horde-version"><?php echo $this->h($this->version) ?></div>
   <div id="horde-navigation">
 <?php echo $this->menu->getTree() ?>
   </div>
 <?php if ($this->logoutUrl): ?>
-  <div id="horde-logout"><a class="icon" title="<?php echo _("Log out") ?>" href="<?php echo $this->escape($this->logoutUrl) ?>"></a></div>
+  <div id="horde-logout"><a class="icon" title="<?php echo _("Log out") ?>" href="<?php echo $this->h($this->logoutUrl) ?>"></a></div>
 <?php elseif ($this->loginUrl): ?>
-  <div id="horde-login"><a class="icon" title="<?php echo _("Log in") ?>" href="<?php echo $this->escape($this->loginUrl) ?>"></a></div>
+  <div id="horde-login"><a class="icon" title="<?php echo _("Log in") ?>" href="<?php echo $this->h($this->loginUrl) ?>"></a></div>
 <?php endif ?>
 <?php if ($this->search): ?>
   <div id="horde-search">

--- a/templates/topbar/_menubar.html.php
+++ b/templates/topbar/_menubar.html.php
@@ -1,13 +1,13 @@
 <div id="horde-head">
-  <div id="horde-logo"><a class="icon" href="<?php echo $this->portalUrl ?>"></a></div>
+  <div id="horde-logo"><a class="icon" href="<?php echo $this->escape($this->portalUrl) ?>"></a></div>
   <div id="horde-version"><?php echo $this->h($this->version) ?></div>
   <div id="horde-navigation">
 <?php echo $this->menu->getTree() ?>
   </div>
 <?php if ($this->logoutUrl): ?>
-  <div id="horde-logout"><a class="icon" title="<?php echo _("Log out") ?>" href="<?php echo $this->logoutUrl ?>"></a></div>
+  <div id="horde-logout"><a class="icon" title="<?php echo _("Log out") ?>" href="<?php echo $this->escape($this->logoutUrl) ?>"></a></div>
 <?php elseif ($this->loginUrl): ?>
-  <div id="horde-login"><a class="icon" title="<?php echo _("Log in") ?>" href="<?php echo $this->loginUrl ?>"></a></div>
+  <div id="horde-login"><a class="icon" title="<?php echo _("Log in") ?>" href="<?php echo $this->escape($this->loginUrl) ?>"></a></div>
 <?php endif ?>
 <?php if ($this->search): ?>
   <div id="horde-search">


### PR DESCRIPTION
## Summary

- `fix(services): cast Variables magic-property to string before substr() in download endpoint`
- `fix(topbar): HTML-escape URLs in legacy menubar template`

The topbar commit is follow-up cleanup to horde/Core#178, applying the build-raw + escape-at-print convention to the legacy desktop menubar.