### PR TITLE
fix(config): hide ActiveSync tab when horde/activesync is not installed

### DIFF
--- a/src/Cli/SetupBundle.php
+++ b/src/Cli/SetupBundle.php
@@ -5,7 +5,7 @@ namespace Horde\Horde\Cli;
 use Horde_Argv_Parser;
 use Horde_Argv_Values;
 use Horde_Config;
-use Horde_Config_Form;
+use Horde\Horde\Config\Form as HordeConfigForm;
 use Horde_Core_Bundle;
 use Horde_Core_Cli;
 use Horde_Registry;
@@ -80,7 +80,7 @@ class SetupBundle extends Horde_Core_Bundle
         $this->cliValues = $parser->values;
         // Apply CLI values to the existing configuration.
         $vars = new Variables();
-        $form = new Horde_Config_Form($vars, 'horde', true);
+        $form = new HordeConfigForm($vars, 'horde', true);
         // Cli trumps existing configuration.
         foreach ($this->filteredCliValues() as $key => $value) {
             // Set the value in the variables object.
@@ -99,7 +99,7 @@ class SetupBundle extends Horde_Core_Bundle
             'help' => 'Outputs usage information',
         ]);
         $vars = new Variables();
-        $form = new Horde_Config_Form($vars, 'horde', true);
+        $form = new HordeConfigForm($vars, 'horde', true);
         $option = null;
         foreach ($form->getVariables() as $configField) {
             // Setup CLI options from config Form
@@ -212,7 +212,7 @@ class SetupBundle extends Horde_Core_Bundle
         $sql_config = $this->_config->configSQL('');
 
         $vars = new Variables();
-        $form = new Horde_Config_Form($vars, 'horde', true);
+        $form = new HordeConfigForm($vars, 'horde', true);
         $this->_cli->question(
             $vars,
             'sql',
@@ -240,7 +240,7 @@ class SetupBundle extends Horde_Core_Bundle
     {
         $vars = new Variables();
         // Ensure we don't lose existing configuration.
-        new Horde_Config_Form($vars, 'horde', true);
+        new HordeConfigForm($vars, 'horde', true);
         // Set default to SQL authentication unless something is already configured.
         $vars->auth__driver ??= 'sql';
         $vars->auth__params__driverconfig ??= 'horde';
@@ -257,7 +257,7 @@ class SetupBundle extends Horde_Core_Bundle
         $this->writeConfig($vars);
         // Auth backend should be setup by now, so we can check if the user exists.
 
-        $form = new Horde_Config_Form($vars, 'horde', true);
+        $form = new HordeConfigForm($vars, 'horde', true);
         $this->_cli->writeln();
         $this->_cli->writeln($this->_cli->bold('Configuring global administrator settings'));
         // TODO: Move getting the factory to constructor

--- a/src/Config/Form.php
+++ b/src/Config/Form.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (LGPL). If you
+ * did not receive this file, see http://www.horde.org/licenses/lgpl21.
+ *
+ * @author  Torben Dannhauer <torben@dannhauer.de>
+ * @category Horde
+ * @copyright 2026 The Horde Project
+ * @license  http://www.horde.org/licenses/lgpl21 LGPL 2.1
+ * @package  Horde
+ */
+
+namespace Horde\Horde\Config;
+
+use Horde_Config_Form;
+
+class Form extends Horde_Config_Form
+{
+    public function __construct(&$vars, $app = 'horde', $fillvars = false)
+    {
+        parent::__construct($vars, $app, $fillvars);
+    }
+
+    protected function _buildVariables($config, $prefix = '')
+    {
+        if ($prefix === '' && !class_exists('Horde_ActiveSync')) {
+            $config = $this->_filterActiveSyncConfig($config);
+        }
+
+        parent::_buildVariables($config, $prefix);
+    }
+
+    /**
+     * Remove ActiveSync configuration from the top-level config tree when
+     * the optional horde/activesync package is not installed.
+     */
+    protected function _filterActiveSyncConfig(array $config): array
+    {
+        $filtered = [];
+
+        foreach ($config as $name => $configitem) {
+            if ($name === 'activesync') {
+                continue;
+            }
+
+            if (is_array($configitem) && ($configitem['tab'] ?? null) === 'activesync') {
+                continue;
+            }
+
+            $filtered[$name] = $configitem;
+        }
+
+        return $filtered;
+    }
+}

--- a/test/Unit/Config/FormTest.php
+++ b/test/Unit/Config/FormTest.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * Tests for Horde configuration form ActiveSync tab visibility.
+ *
+ * @author   Torben Dannhauer <torben@dannhauer.de>
+ * @license  http://www.horde.org/licenses/lgpl LGPL
+ * @copyright 2026 The Horde Project (http://www.horde.org/)
+ * @package  Horde
+ */
+
+use Horde\Horde\Config\Form;
+use PHPUnit\Framework\TestCase;
+
+class Horde_Unit_Config_FormTest extends TestCase
+{
+    public function testFilterActiveSyncConfigRemovesTabAndSection()
+    {
+        $form = $this->_createFormWithoutConstructor();
+        $method = (new ReflectionClass($form))->getMethod('_filterActiveSyncConfig');
+        $method->setAccessible(true);
+
+        $config = [
+            'general' => ['foo' => 'bar'],
+            'uniqid1' => ['tab' => 'activesync', 'desc' => 'ActiveSync'],
+            'activesync' => ['enabled' => ['_type' => 'boolean']],
+        ];
+
+        $filtered = $method->invoke($form, $config);
+
+        $this->assertSame(['general' => ['foo' => 'bar']], $filtered);
+    }
+
+    public function testFilterActiveSyncConfigLeavesOtherTabsUntouched()
+    {
+        $form = $this->_createFormWithoutConstructor();
+        $method = (new ReflectionClass($form))->getMethod('_filterActiveSyncConfig');
+        $method->setAccessible(true);
+
+        $config = [
+            'uniqid1' => ['tab' => 'general', 'desc' => 'General'],
+            'general' => ['foo' => 'bar'],
+            'uniqid2' => ['tab' => 'db', 'desc' => 'Database'],
+            'sql' => ['phptype' => ['_type' => 'enum']],
+        ];
+
+        $filtered = $method->invoke($form, $config);
+
+        $this->assertSame($config, $filtered);
+    }
+
+    private function _createFormWithoutConstructor(): Form
+    {
+        $ref = new ReflectionClass(Form::class);
+        return $ref->newInstanceWithoutConstructor();
+    }
+}


### PR DESCRIPTION
## Summary
- Hide the ActiveSync configuration tab during Horde setup when the optional `horde/activesync` package is not installed
- Add `Horde\Horde\Config\Form`, picked up automatically by `admin/config/config.php`
- Use the same form class in `horde-setup` so CLI setup does not expose ActiveSync options without the package

## Motivation
Users reported confusion during initial setup: the ActiveSync tab appeared in the Horde configuration UI even when `horde/activesync` was not installed. The tab implies ActiveSync can be configured, but the library is missing and the feature cannot work.

`horde/activesync` is listed under `suggest` in `composer.json`, not `require`. Other parts of Horde already gate on `class_exists('Horde_ActiveSync')` (for example `rpc.php`, the test script, and the ActiveSync admin diagnostics page).

## Changes
- **`src/Config/Form.php`** — extends `Horde_Config_Form`; filters the top-level `activesync` section and tab marker from the config tree when `Horde_ActiveSync` is not available; constructor defaults `$app` to `horde` so `admin/config/config.php` can instantiate it with only `$vars` (same pattern as `Horde\Gollem\Config\Form`)
- **`src/Cli/SetupBundle.php`** — replace `Horde_Config_Form` with `Horde\Horde\Config\Form` at all five call sites
- **`test/Unit/Config/FormTest.php`** — unit tests for the config-tree filter logic

## Test plan
- [ ] `vendor/bin/phpunit -c phpunit.xml.dist test/Unit/Config/FormTest.php`
- [ ] On an install **without** `horde/activesync`: open Horde Admin → Configuration → Horde — confirm no ActiveSync tab
- [ ] On an install **with** `horde/activesync`: confirm the ActiveSync tab still appears and settings can be saved
- [ ] Run `horde-setup` without the package — confirm no ActiveSync-related CLI options are listed
