### PR TITLE
fix(health-check): catch Throwable when probing modern AuthService

### DIFF
--- a/src/Service/Health/HealthCheckService.php
+++ b/src/Service/Health/HealthCheckService.php
@@ -469,11 +469,15 @@ class HealthCheckService
             $authDriver = $conf['auth']['driver'] ?? 'not configured';
 
             try {
-                // Try modern AuthService first
+                // Try modern AuthService first. Fall back to the legacy
+                // 'Horde_Auth' string binding on ANY failure — a missing
+                // method surfaces as \Error (not Exception) on PHP 7+,
+                // so catching Exception alone leaks it as a 500 rather
+                // than reaching the fallback.
                 try {
                     $authService = $this->injector->getInstance(\Horde\Core\Auth\AuthService::class);
                     $auth = $authService->getBackend();
-                } catch (Exception $e) {
+                } catch (\Throwable $e) {
                     // Fall back to legacy 'Horde_Auth' string binding
                     $auth = $this->injector->getInstance('Horde_Auth');
                 }


### PR DESCRIPTION
## Summary

`HealthCheckService::checkAuth()` probes the modern `Horde\Core\Auth\AuthService` with a fallback to the legacy `Horde_Auth` binding. The modern class no longer exposes `getBackend()`, and PHP raises `Error` (not `Exception`) for undefined methods. The `catch (Exception $e)` fallback never fires, so the fatal bubbles up as a 500 rather than reaching the legacy path.

Widen the catch to `\Throwable`. The fallback was clearly designed to run on ANY failure of the modern path; the narrow catch is a bug, not intentional.

Reproducer against a locally-installed Horde:

    hordectl test all
    → 500 Internal Server Error (before)
    → per-subsystem status report with Auth: OK (after)

The other `catch (Exception)` sites in this file wrap outer blocks that catch their own errors; they're out of scope for this narrow fix.

Surfaced while dogfooding `hordectl webserver-config` in horde/hordectl PR #17 CI. Companion fix to horde/Core PR #195 (Prefs Storage null-registry guard) which was the first of two admin-API 500s uncovered by that CI run.