### PR TITLE
fix(horde): catch CapabilityException from lazy session generator

### DIFF
--- a/admin/sessions.php
+++ b/admin/sessions.php
@@ -39,7 +39,10 @@ try {
     );
 
     try {
-        $sessionIds = $admin->listAll();
+        // listAll() returns a lazy Generator: force it to run here (rather
+        // than at the foreach below) so a CapabilityException from an
+        // unsupported backend is caught by this try/catch.
+        $sessionIds = iterator_to_array($admin->listAll());
     } catch (CapabilityException $e) {
         // Backend cannot enumerate sessions (e.g. native files). Surface a
         // friendly error rather than crashing the admin page.


### PR DESCRIPTION
## Summary
- Fix uncaught fatal error on the admin Session Administration page when the configured session backend does not support iteration (e.g. native PHP file sessions).

## Motivation
Reported in horde/Core#192: opening Administration → Configuration → Sessions throws a fatal `Horde\SessionHandler\Exception\CapabilityException: Backend does not support session iteration`, even though `admin/sessions.php` has a try/catch specifically meant to handle this case.

## Root cause
`SessionAdministrator::listAll()` is implemented as a PHP generator (uses `yield`). Calling a generator function does not execute its body — that only happens once the generator is iterated. So `$sessionIds = $admin->listAll();` inside the try block never throws; the `CapabilityException` is instead thrown later, at the `foreach ($sessionIds as $sessionId)` outside that try block. Since `CapabilityException` doesn't extend `Horde_Exception`, the outer catch doesn't catch it either, so it becomes an uncaught fatal error.

## Changes
- `admin/sessions.php`: wrap `$admin->listAll()` in `iterator_to_array()` so the generator is fully evaluated inside the try block, letting the existing `catch (CapabilityException $e)` handle it as originally intended.

## Test plan
- [ ] With a session backend that implements `IterableSessionBackend` (e.g. SQL/hashtable), confirm the Session Administration page still lists sessions correctly.
- [ ] With a non-iterable backend (e.g. native file sessions), confirm the page now shows the friendly "Backend does not support session iteration" notice instead of a fatal error.
