### PR TITLE
fix(horde): load OAuth admin page when OAuth is not configured

### DIFF
--- a/src/Admin/OAuthProviderController.php
+++ b/src/Admin/OAuthProviderController.php
@@ -23,8 +23,9 @@ use Horde\Core\PageOutput\PageComposer;
 use Horde\Core\PageOutput\PageMeta;
 use Horde\Core\PageOutput\ViewMode;
 use Horde\Core\PageOutput\ViewModeConfigurator;
-use Horde\Core\Service\OAuthProviderConfigRepository;
 use Horde\Core\Service\Exception\OAuthProviderConfigNotFoundException;
+use Horde\Core\Service\NullOAuthProviderConfigRepository;
+use Horde\Core\Service\OAuthProviderConfigRepository;
 use Horde\Core\Sidebar\AdminSidebarPanel;
 use Horde\Core\Sidebar\SidebarRenderer;
 use Horde\Core\Topbar\TopbarBuilder;
@@ -57,7 +58,7 @@ class OAuthProviderController implements RequestHandlerInterface
         private readonly AdminSidebarPanel $adminPanel,
         private readonly SidebarRenderer $sidebarRenderer,
         private readonly Horde_Registry $registry,
-        private readonly RouteUrlWriter $urlWriter,
+        private readonly ?RouteUrlWriter $urlWriter = null,
         private readonly ?ProviderDiscovery $discovery = null,
     ) {}
 
@@ -90,6 +91,8 @@ class OAuthProviderController implements RequestHandlerInterface
         $view->presets = $availablePresets;
         $view->baseUrl = $this->getBaseUrl();
         $view->statusUrl = $webroot . '/admin/authentication/status/';
+        $view->storageUnavailable = $this->repository instanceof NullOAuthProviderConfigRepository;
+        $view->configUrl = $webroot . '/admin/config/config.php?app=horde';
 
         $html = $this->renderChrome(
             _("OAuth Providers"),
@@ -188,7 +191,7 @@ class OAuthProviderController implements RequestHandlerInterface
         $view->provider = $provider;
         $view->baseUrl = $baseUrl;
         $view->setupNotes = $preset['notes'] ?? '';
-        $view->callbackUrl = $this->urlWriter->absoluteUrlFor('SettingsOAuthCallback');
+        $view->callbackUrl = $this->resolveCallbackUrl();
 
         $template = $provider['type'] === 'service_app' ? 'edit-service-app' : 'edit-oauth2';
 
@@ -416,5 +419,17 @@ class OAuthProviderController implements RequestHandlerInterface
     private function getBaseUrl(): string
     {
         return rtrim($this->registry->get('webroot', 'horde'), '/') . '/admin/authentication/provider';
+    }
+
+    private function resolveCallbackUrl(): string
+    {
+        if ($this->urlWriter !== null) {
+            $url = $this->urlWriter->absoluteUrlFor('SettingsOAuthCallback');
+            if ($url !== null) {
+                return $url;
+            }
+        }
+
+        return rtrim($this->registry->get('webroot', 'horde'), '/') . '/settings/oauth/callback';
     }
 }

--- a/templates/admin/oauthprovider/list.html.php
+++ b/templates/admin/oauthprovider/list.html.php
@@ -5,6 +5,16 @@
     <a href="<?php echo $this->h($this->statusUrl) ?>" class="btn btn-secondary"><?php echo _("System Status") ?></a>
   </div>
 
+  <?php if (!empty($this->storageUnavailable)): ?>
+  <div class="settings-empty">
+    <?php echo sprintf(
+        _("Providers cannot be saved. Configure the SQL database in %sHorde Settings%s."),
+        '<a href="' . $this->h($this->configUrl) . '">',
+        '</a>'
+    ) ?>
+  </div>
+  <?php endif; ?>
+
   <?php if (count($this->providers)): ?>
   <ul class="settings-provider-list">
     <?php foreach ($this->providers as $provider): ?>


### PR DESCRIPTION
## Summary
- Make `RouteUrlWriter` optional in `OAuthProviderController` so list/edit pages can load without full URL-generation dependencies
- Show the existing storage-unavailable notice when the null OAuth provider repository is active
- Fall back OAuth callback URLs to the webroot path when named routes are unavailable

## Motivation
The OAuth provider admin page should be usable on instances without OAuth configured. Controller construction and the list template should degrade gracefully instead of failing hard when storage or route URL generation is incomplete.

This complements https://github.com/horde/Core/pull/198 (DbServiceFactory Unix-socket fix), which resolves the fatal PDO error on PostgreSQL socket deployments.

## Changes
- `OAuthProviderController`: optional `RouteUrlWriter`, `resolveCallbackUrl()`, storage-unavailable view data
- `templates/admin/oauthprovider/list.html.php`: notice when provider storage is unavailable

## Test plan
- [x] OAuth provider list renders HTTP 200 with null repository forced
- [x] Storage-unavailable notice appears when `NullOAuthProviderConfigRepository` is active
- [ ] Manual: open `/horde/admin/authentication/provider/` without OAuth providers configured
