### PR TITLE
chore(horde): enable ActiveSync Sync streaming by default

### DIFF
--- a/config/conf.xml
+++ b/config/conf.xml
@@ -2574,7 +2574,7 @@ cookie policy. See session configuration options.">$_SERVER['SERVER_NAME'] ?? $_
       batches.</configdescription>
       <configboolean name="streaming" desc="Stream Sync responses
       incrementally instead of buffering the full response. Recommended for
-      deployments with Android Gmail/Nine clients.">false</configboolean>
+      deployments with Android Gmail/Nine clients.">true</configboolean>
       <configinteger name="maxmessagesperresponse" desc="Maximum number of
       exported changes per Sync response when streaming; more changes are
       announced via MOREAVAILABLE and delivered in follow-up requests. Only


### PR DESCRIPTION
## Summary
- Enable ActiveSync Sync response streaming by default in `conf.xml`.

## Motivation
ActiveSync #83 (incremental Sync WBXML delivery) was validated on Gmail Android
and iOS. Streaming is no longer opt-in; new installs should get the safer default.
Rollback remains available via `streaming = false`.

## Changes
- `config/conf.xml`: `activesync.sync.streaming` default `false` → `true`

Companion doc/comment updates were pushed directly to `FRAMEWORK_6_0` in
`horde/ActiveSync` and `horde/rpc`.

## Test plan
- [ ] Fresh Horde config generation shows streaming enabled
- [ ] Existing deployments with an explicit `streaming` value are unchanged
- [ ] Setting `streaming = false` restores buffered Content-Length behaviour
