### PR TITLE
feat(activesync): add maxsearchtime for Gmail mailbox Search

### DIFF
--- a/config/conf.xml
+++ b/config/conf.xml
@@ -2594,6 +2594,11 @@ cookie policy. See session configuration options.">$_SERVER['SERVER_NAME'] ?? $_
       seconds per Sync response before emitting MOREAVAILABLE and continuing
       in the next request. Only used when streaming is disabled. 0 disables
       the time budget.">25</configinteger>
+      <configinteger name="maxsearchtime" desc="Wall-clock cap in seconds
+      for mailbox Search IMAP work. Used only for clients that need a
+      complete Search document quickly (Gmail Android). When exceeded,
+      Horde stops scanning further folders and returns the hits found so
+      far as a complete Search response. 0 disables the cap.">20</configinteger>
       <configheader>Forced Sync Body Truncation Size</configheader>
       <configdescription>Override each client's BodyPreference
       TruncationSize for Sync exports only (ItemOperations Fetch when


### PR DESCRIPTION
## Summary
- Add `$conf['activesync']['sync']['maxsearchtime']` (default 20) for mailbox Search IMAP work.

## Motivation
Gmail Android Search needs a complete Search document within ~40s (horde/ActiveSync#104). The ActiveSync device quirk honors this cap; other clients are unaffected. The PHP default is 20s even without regenerating `conf.php`.

## Changes
- `config/conf.xml`: `maxsearchtime` under ActiveSync → Sync Response Delivery.

Companion PRs:
- https://github.com/horde/ActiveSync/pull/105
- https://github.com/horde/Core/pull/223
- https://github.com/horde/Rpc/pull/7

## Test plan
- [ ] Horde admin UI shows the new integer after regenerating config
- [ ] Gmail Search still completes when left at the default 20
